### PR TITLE
ATB-113 Define Metrics and Alarms for API Gateway Access logs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -55,6 +55,10 @@ Parameters:
   VpcStackName:
     Description: The name of the stack that defines the VPC in which this container will run.
     Type: String
+  AlertingStackName:
+    Description: The name of the stack that defines the Alerting resources
+    Type: String
+    Default: platform-alerting
   BackendStackName:
     Description: The name of the backend stack
     Type: String
@@ -92,6 +96,11 @@ Parameters:
     Default: user_services
 
 Conditions:
+  IsNotDevelopment: !Or
+    - !Equals [!Ref Environment, build]
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
   IsProduction: !Equals [!Ref Environment, production]
   UsePermissionsBoundary:
     Fn::Not:
@@ -753,6 +762,7 @@ Resources:
   #
   # App domain
   #
+
   AppFrontCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
     Properties:
@@ -1426,6 +1436,155 @@ Resources:
                 "aws:SourceAccount": !Ref AWS::AccountId
               Bool:
                 "aws:SecureTransport": true
+
+  #
+  # Metrics and Alarms
+  #
+
+  # API Gateway Alarms
+
+  # 4xx Status Code
+  ApiGateway4xxStatusAlarm:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ApiGateway4xxStatusAlarm"
+      AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
+      ActionsEnabled: false  # disabled until we're ready to invoke alarm actions
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+      OKActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 1
+      TreatMissingData: missing
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<10,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations)*100
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 4xx
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 60
+            Stat: Sum
+
+  # 5xx Status Code
+  ApiGateway5xxStatusAlarm:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ApiGateway5xxStatusAlarm"
+      AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
+      ActionsEnabled: false  # disabled until we're ready to invoke alarm actions
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+      OKActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 1
+      TreatMissingData: missing
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<10,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations)*100
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5xx
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 60
+            Stat: Sum
+
+  # Latency
+  ApiGatewayLatencyAlarm:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ApiGatewayLatencyAlarm"
+      AlarmDescription: "Trigger the alarm if response latency exceeds 2.5 seconds with the minimum of 10 invocations in 2 out of the last 5 minutes"
+      ActionsEnabled: false  # disabled until we're ready to invoke alarm actions
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      OKActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 2500
+      TreatMissingData: missing
+      Metrics:
+        - Id: safeLatency
+          Label: safeLatency
+          ReturnData: true
+          Expression: IF(invocations<10,0,maxLatency)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 60
+            Stat: Sum
+        - Id: maxLatency
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Latency
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 60
+            Stat: Maximum
 
   #
   # DynamoDB

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1448,7 +1448,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGateway4xxStatusAlarm"
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: false  # disabled until we're ready to invoke alarm actions
+      ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       OKActions:
@@ -1497,7 +1497,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGateway5xxStatusAlarm"
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: false  # disabled until we're ready to invoke alarm actions
+      ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       OKActions:
@@ -1546,7 +1546,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGatewayLatencyAlarm"
       AlarmDescription: "Trigger the alarm if response latency exceeds 2.5 seconds with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: false  # disabled until we're ready to invoke alarm actions
+      ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
       OKActions:


### PR DESCRIPTION
## What?

Defined the following Metric Filter and Alarm for both the API Gateway Access CloudWatch logs:

- API Gateway 4xx status errors in /apigateway/account-mgmt-frontend/access
- API Gateway 5xx status errors in /apigateway/account-mgmt-frontend/access
- API Gateway latency threshold in /apigateway/account-mgmt-frontend/access

I have enabled alarm actions to publish to our alerting SNS topics which in turn will send notifications to our `govuk-accounts-notifications` slack channel so we can monitor the sensitivity of the new defined alarms. Our PagerDuty endpoint has not yet been configured and therefore no notifications will be sent there yet. I recommend we hold off with PagerDuty integration until we are happy with the initial alarm thresholds.

**NOTE:** This PR should not be merged before https://govukverify.atlassian.net/browse/ATB-67 has been merged and has progressed through all environments.

## Why?

To facilitate monitoring of the Authentication Account Management front-end application for server and latency related errors

## Testing

Note: Testing was complete for 4xx errors as this was simple to invoke simply by hitting the home.build.account.gov.uk/manage-your-account endpoint when not signed in. Whereas 5xx would have required additional effort to invoke a status error but the implementation is the same.
![Screenshot 2022-11-14 at 12 04 15](https://user-images.githubusercontent.com/110469146/201941794-8dfc2c56-3a52-4a51-ba15-28bff876342b.png)

