### PR TITLE
ATB-162 Setting nodejs timeout values to match ALB config 

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,21 @@
 import { createApp } from "./app";
 import { logger } from "./utils/logger";
 
+
 const port: number | string = process.env.PORT || 6001;
 
 (async () => {
   const app = await createApp();
-  app
+  const server = app
     .listen(port, () => {
       logger.info(`Server listening on port ${port}`);
     })
     .on("error", (error: Error) => {
       logger.error(`Unable to start server because of ${error.message}`);
     });
+  server.keepAliveTimeout = 61 * 1000;
+  server.headersTimeout = 91 * 1000;
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);
 });
+


### PR DESCRIPTION
## Proposed changes
Matched the Amazon Load Balancer configurations of the keepAliveTimeout values to the nodejs timeout values.

### What changed

Adding configurations for keepAliveTimeout value and headersTimeout value to match ALB configurations of:
  server.keepAliveTimeout = 61 * 1000;
  server.headersTimeout = 91 * 1000;

### Why did it change

The default of the nodeJS keepAliveTimeout is set at 5 seconds, but this needs to be extended in order to stop random 5XX and 4XX errors being emitted from the load balancers in front of the nodeJS ECS fargate containers. 

### Issue tracking

(https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3409903626/Load+Balancer+Errors) details the issue further.

The relevant ticket:  [[ATB-162]](https://govukverify.atlassian.net/jira/software/c/projects/ATB/boards/241?modal=detail&selectedIssue=ATB-162&assignee=635679e1fc0cc7a600ae36d5)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] [Application configuration](https://govukverify.atlassian.net/TODO) is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

<!-- Delete if changes DO NOT involve Dockerfile -->
- [ ] Let the tech lead know if the Dockerfile has changed

### Other considerations
- [x] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[ATB-162]: https://govukverify.atlassian.net/browse/ATB-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ