### PR TITLE
ATB-65 Define and create CloudWatch dashboard

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1583,6 +1583,270 @@ Resources:
                   Value: !Ref ApiGateway
             Period: 60
             Stat: Maximum
+  #
+  # CloudWatch Dashboard
+  #
+
+  AMFCloudWatchDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardBody:
+        !Sub >- 
+       {
+        "start": "-PT6H",
+        "periodOverride": "inherit",
+        "widgets": [ {
+          "height": 6,
+          "width": 12,
+          "y": 0,
+          "x": 0,
+          "type": "metric",
+          "properties": {
+            "title": "API Gateway 4xx, 5xx Errors and Total Invocations",
+            "region": "${AWS::Region}",
+            "metrics": [
+              [ "AWS/ApiGateway", "4xx", "ApiId", "${ApiGateway}" ],
+              [ "AWS/ApiGateway", "5xx", "ApiId", "${ApiGateway}" ],
+              [ "AWS/ApiGateway", "Count", "ApiId", "${ApiGateway}" ]
+            ],
+            "view": "timeSeries",
+            "stacked": false,
+            "stat": "Sum",
+            "period": 60
+          }
+        },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "API Gateway Latency",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/ApiGateway", "Latency", "ApiId", "${ApiGateway}" ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Maximum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 6,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "metrics": [
+                [ "AWS/ApiGateway", "Count", "ApiId", "${ApiGateway}",
+                  {
+                    "stat": "Sum", "label": "API Request Count"
+                  }
+                ],
+                [ "AWS/ECS", "CPUUtilization", "ClusterName", "${ECSCluster}",
+                  "ServiceName", "${ContainerService.Name}", { "label": "ECS CPUUtilization" }
+                ],
+                [ "AWS/ECS", "MemoryUtilization", "ClusterName", "${ECSCluster}",
+                  "ServiceName", "${ContainerService.Name}", { "label": "ECS MemoryUtilization" }
+                ]
+              ],
+              "title": "ECS Auto Scaling (Production Only)",
+              "region": "${AWS::Region}",
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Maximum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "ECS Running Task Count, Desired And Pending Task Count",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "ECS/ContainerInsights", "RunningTaskCount", "ClusterName", "${ECSCluster}",
+                  "ServiceName", "${ContainerService.Name}"
+                ],
+                [ "ECS/ContainerInsights", "DesiredTaskCount", "ClusterName", "${ECSCluster}",
+                  "ServiceName", "${ContainerService.Name}"
+                ],
+                [ "ECS/ContainerInsights", "PendingTaskCount", "ClusterName", "${ECSCluster}",
+                    "ServiceName", "${ContainerService.Name}"
+                  ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+           {
+             "height": 6,
+             "width": 12,
+             "y": 0,
+             "x": 12,
+             "type": "metric",
+             "properties": {
+               "title": "ECS Cluster Service Count",
+               "region": "${AWS::Region}",
+               "metrics": [
+                 [ "ECS/ContainerInsights", "ServiceCount", "ClusterName", "${ECSCluster}" ]
+               ],
+               "view": "timeSeries",
+               "stacked": false,
+               "stat": "Average",
+               "period": 60
+             }
+           },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "Number Of Requests Made To ELB vs Response Time",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/ApplicationELB", "RequestCount", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}", { "yAxis": "right" } ],
+                [ "AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}",
+                  {
+                    "stat": "Average"
+                  }
+                ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "Load Balancer Endpoint Functionality",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/ApplicationELB", "ActiveConnectionCount", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}",{ "yAxis": "right" } ],
+                [ "AWS/ApplicationELB", "ProcessedBytes", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "ELB 502,503 And 504 Errors",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/ApplicationELB", "HTTPCode_ELB_502_Count", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ],
+                [ "AWS/ApplicationELB", "HTTPCode_ELB_503_Count", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ],
+                [ "AWS/ApplicationELB", "HTTPCode_ELB_504_Count", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": " ELB Target Health Check",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/ApplicationELB", "HealthyHostCount", "TargetGroup","${ApplicationLoadBalancerTargetGroupBlue.TargetGroupFullName}", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ],
+                [ "AWS/ApplicationELB", "UnHealthyHostCount","TargetGroup","${ApplicationLoadBalancerTargetGroupBlue.TargetGroupFullName}", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "Unsuccessful Connections Between Load Balancer And Host",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/ApplicationELB", "TargetConnectionErrorCount", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+          {
+            "height": 6,
+            "width": 12,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+              "title": "DynamoDB Read And Write Capacity",
+              "region": "${AWS::Region}",
+              "metrics": [
+                [ "AWS/DynamoDB", "ConsumedReadCapacityUnits", "TableName", "${SessionsDynamoDB}" ],
+                [ "AWS/DynamoDB", "ConsumedWriteCapacityUnits", "TableName", "${SessionsDynamoDB}" ]
+              ],
+              "view": "timeSeries",
+              "stacked": false,
+              "stat": "Sum",
+              "period": 60
+            }
+          },
+           {
+               "height": 6,
+               "width": 12,
+               "y": 0,
+               "x": 12,
+               "type": "metric",
+               "properties": {
+                 "title": "DynamoDB Average Latency",
+                 "region": "${AWS::Region}",
+                 "metrics": [
+                   [ "AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", "${SessionsDynamoDB}", "Operation", "GetItem"],
+                   [ "AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", "${SessionsDynamoDB}", "Operation", "PutItem"],   
+                   [ "AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", "${SessionsDynamoDB}", "Operation", "UpdateItem"],
+                   [ "AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", "${SessionsDynamoDB}", "Operation", "DeleteItem"]
+                 ],
+                 "view": "timeSeries",
+                 "stacked": false,
+                 "stat": "Average",
+                 "period": 60
+               }
+             }
+          ]
+        }
+      DashboardName: !Sub "${AWS::StackName}-AMF"
 
   #
   # DynamoDB

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1712,7 +1712,7 @@ Resources:
             "x": 12,
             "type": "metric",
             "properties": {
-              "title": "Number Of Requests Made To ELB vs Response Time",
+              "title": "Number Of Requests Made To ALB vs Response Time",
               "region": "${AWS::Region}",
               "metrics": [
                 [ "AWS/ApplicationELB", "RequestCount", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}", { "yAxis": "right" } ],
@@ -1735,7 +1735,7 @@ Resources:
             "x": 12,
             "type": "metric",
             "properties": {
-              "title": "Load Balancer Endpoint Functionality",
+              "title": "ALB Endpoint Functionality",
               "region": "${AWS::Region}",
               "metrics": [
                 [ "AWS/ApplicationELB", "ActiveConnectionCount", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}",{ "yAxis": "right" } ],
@@ -1754,7 +1754,7 @@ Resources:
             "x": 12,
             "type": "metric",
             "properties": {
-              "title": "ELB 502,503 And 504 Errors",
+              "title": "ALB 502,503 And 504 Errors",
               "region": "${AWS::Region}",
               "metrics": [
                 [ "AWS/ApplicationELB", "HTTPCode_ELB_502_Count", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ],
@@ -1774,7 +1774,7 @@ Resources:
             "x": 12,
             "type": "metric",
             "properties": {
-              "title": " ELB Target Health Check",
+              "title": " ALB Target Health Check",
               "region": "${AWS::Region}",
               "metrics": [
                 [ "AWS/ApplicationELB", "HealthyHostCount", "TargetGroup","${ApplicationLoadBalancerTargetGroupBlue.TargetGroupFullName}", "LoadBalancer", "${ApplicationLoadBalancer.LoadBalancerFullName}" ],


### PR DESCRIPTION
## What? & Testing 

Created a Dashboard titled AMFCloudWatchDashboard that includes metric graphs for ECS, ELB, and DynamoDB. 
<img width="1397" alt="Screenshot 2023-02-17 at 15 15 40" src="https://user-images.githubusercontent.com/116737136/219693141-24f480d7-a3db-4fa8-8587-5708cc8ff715.png">


Each Metric Graph: 
- 'API Gateway 4xx, 5xx Errors and Total Invocations' illustrates an overview of the amount of 4xx and 5xx errors in comparison to the total number of API Gateway invocations. A surge in either 4xx and 5xx errors for a set amount of time is a cause for concern to be investigated. Experiencing more requests than usual could indicate an endpoint returning an error message causing multiple re-entries on client side or if there are also less requests than usual, there could be a permissions issues withholding API calls. 

<img width="704" alt="Screenshot 2023-02-16 at 14 40 11" src="https://user-images.githubusercontent.com/116737136/219395355-ebf877c6-8eb6-4a2e-8c28-810ecaa10eaf.png">


- 'API Gateway Latency' illustrates the maximum latency measured in milliseconds . This is important to track to ensure there is no significant lack of delay when the API received the request to when it responds impacting performance.
<img width="696" alt="Screenshot 2023-02-16 at 14 39 26" src="https://user-images.githubusercontent.com/116737136/219395174-cb5974b6-e0f9-4d2f-93b4-4e216f6901f9.png">


- ' ECS Auto Scaling (Production Only)' illustrates the sum number of API Gateway invocations, and maximum ECS CPUUtilization and MemoryUtilization. 

<img width="1427" alt="Screenshot 2023-02-16 at 15 14 50" src="https://user-images.githubusercontent.com/116737136/219407097-2e598dbf-1df7-40d2-b873-b0b7386b306a.png">

 - 'ECS Running Task Count, Desired and Pending Task Count' illustrates the number of tasks in the ECS Service that are currently running, number of tasks pending and the desired amount of tasks that have been scheduled to run as indicated in the task definition. Important to highlight that tasks are running as expected. For example if we see a drop in the ratio of Running Task Count to Desired Task Count could potentially indicate ECS is running into a resource constraint. If a Task is pending and has disappeared could indicated that a Task may have failed an ELB health check. 

<img width="1229" alt="Screenshot 2023-02-17 at 19 10 26" src="https://user-images.githubusercontent.com/116737136/219765413-ec3262ec-bf3a-4a49-b324-5bc704aae656.png">


 - 'ECS Cluster Service Count' illustrates the number of services are running in a cluster. Potentially ECS Service will have this autoscaling enabled in Production; currently ECS Service only as one task attached to it that is running, but in the future presume there will be more, so having this dashboard would be useful to see how many services will be created with demand. 
 
<img width="1231" alt="Screenshot 2023-02-17 at 07 59 13" src="https://user-images.githubusercontent.com/116737136/219585724-4f6878df-50cf-4dcb-84ca-f06cdff412d3.png">

- 'Number of requests made to ELB vs Response Time' illustrates the amount of requests made to the load balancer and the amount of time that it takes for the host to return a response via load balancer. A potential drop in requests could indicate a problem from client end where they are attempting to gain contact with the load balancer, but it's returning errors and client is re-trying, hence a potential surge in number of requests.  

<img width="1228" alt="Screenshot 2023-02-17 at 19 12 01" src="https://user-images.githubusercontent.com/116737136/219765640-67b8b6c7-d1ef-4db7-8e5a-d65b6cb710cc.png">

- 'ALB endpoint functionality' monitors ActiveConnectionCount along with ProcessedBytes. ProcessedBytes will monitor the number of bytes processed by the Load Balancer and compare it to ActiveConnectionCount which displays the number of TCP connections at a given point in time ( connections between client and Load Balancer, along with Load Balancer and Target) , however this metric does not differentiate between connections from the client and to the target. 

<img width="1205" alt="Screenshot 2023-02-21 at 11 27 22" src="https://user-images.githubusercontent.com/116737136/220332933-adfb35fb-0d08-4049-afb8-3f124ed07c3b.png">

- 'ALB 502,503 and 504 errors' illustrates the number of HTTP 502's, 503, and 504 errors that stem from the Load Balancer.  This will provide a deeper understanding of the type of server error for troubleshooting purposes.  

<img width="1216" alt="Screenshot 2023-02-21 at 11 28 18" src="https://user-images.githubusercontent.com/116737136/220333133-d455fa57-2f21-4eb4-863b-a855267e055f.png">


- 'ALB Target Health Check' compares HealthyHostCount with UnHealthyHostCount to showcase TargetGroup is running optimally and receiving requests. Potentially useful to create an alarm for Unhealthy hosts based on the metric. A failed target group health check will not route requests. If UnhealthyHostCount is high you need to investigate and maintain healthy instances in each availability zone for performance purposes. 

<img width="1219" alt="Screenshot 2023-02-21 at 11 29 24" src="https://user-images.githubusercontent.com/116737136/220333330-009bbce1-01cb-4132-b9f8-a96a069c5ec3.png">

- 'Unsuccessful Connections Between Load Balancer And Host' monitors the metric TargetConnectionErrorCount. A high count can cause latency for client since the Load Balancer will re-try the request to the target. Connection errors can happen due to instances being overloaded and rejecting new connections. 

<img width="1231" alt="Screenshot 2023-02-21 at 11 30 29" src="https://user-images.githubusercontent.com/116737136/220333631-a17fe300-6e0a-43be-8079-a34ca635e404.png">


- 'DynamoDB Read and Write Capacity' is useful to showcase a pattern, rather than the actual data itself from one point of view as we are not able to create a dashboard to indicate how many sessions are stored in DynamoDB so this could be helpful to see if there is a huge spike that doesn't follow the pattern indicating some type of malicious activity or whether there is a spike during certain times of the day too. 

<img width="1235" alt="Screenshot 2023-02-17 at 19 18 36" src="https://user-images.githubusercontent.com/116737136/219766815-1ad0a2a6-f7b6-4cfe-b9a9-6a540a969ae7.png">


- 'DynamoDB Average Latency' monitors the latency of PutItem, GetItem, UpdateItem, DeleteItem. Important to monitor if there is a higher latency at a specific point in the journey to resolve issues. 

<img width="1217" alt="Screenshot 2023-02-17 at 19 17 33" src="https://user-images.githubusercontent.com/116737136/219766625-e7c4d2f0-2c6e-411f-9606-7598ba4f46ec.png">



## Why? 

These dashboard will allow you to monitor resource behaviour for AMF to verify that is performing as expected.




*Note: WAF dashboard were not able to be created due to organisational error and so unable to create a cross-region dashboard as illustrated in the image below so will be creating WAF dashboards in Grafana or Splunk potentially if that suits.  
<img width="1130" alt="WAF logging admin error" src="https://user-images.githubusercontent.com/116737136/219641123-206c9f35-e9a1-476d-9098-65e30b903789.png">