### PR TITLE
GUA-618: Add sonarcloud analysis and coverage action

### DIFF
--- a/.github/workflows/build-test-application.yml
+++ b/.github/workflows/build-test-application.yml
@@ -85,20 +85,3 @@ jobs:
       SESSION_SECRET: secret
       SESSION_EXPIRY: 3600000
       SESSION_STORE_TABLE_NAME: account-mgmt-frontend-SessionStore
-
-  code_analysis:
-    runs-on: ubuntu-latest
-    name: "Code Analysis"
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.gitRef || github.ref }}
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,40 @@
+name: Sonarcloud
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  sonarcloud:
+    name: Run Sonar scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.gitRef || github.ref }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
+      - name: Install dependencies
+        run: yarn install
+      - name: Generate coverage report
+        run: yarn test:coverage
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    env:
+      API_BASE_URL: http://localhost:6000/api
+      AM_API_BASE_URL: http://localhost:5000/api
+      SUPPORT_INTERNATIONAL_NUMBERS: 1
+      GOV_ACCOUNTS_PUBLISHING_API_URL: http://localhost:1000/api
+      GOV_ACCOUNTS_PUBLISHING_API_TOKEN: token
+      AM_YOUR_ACCOUNT_URL: some url
+      OIDC_CLIENT_ID: test
+      OIDC_CLIENT_SCOPES: openid
+      SESSION_SECRET: secret
+      SESSION_EXPIRY: 3600000
+      SESSION_STORE_TABLE_NAME: account-mgmt-frontend-SessionStore

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:integration": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"src/**/*-integration.test.ts\"",
     "test:unit": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config --exclude \"src/**/*-integration.test.ts\"  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
     "test": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
-    "test:coverage": "nyc report --reporter=lcov --reporter=text",
+    "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test:unit",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
     "watch-sass": "sass --watch src/assets/scss/application.scss dist/public/style.css"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,6 @@
+sonar.organization=alphagov
 sonar.projectKey=alphagov_di-account-management-frontend
+sonar.projectName=di-account-management-frontend
 sonar.organization=alphagov
 sonar.host.url=https://sonarcloud.io
 


### PR DESCRIPTION
## Proposed changes
Changes to include Sonar cloud analysis and test coverage 

### What changed
Addded a new github actions for dealing with sonarcloud
https://sonarcloud.io/summary/new_code?id=alphagov_di-account-management-frontend&pullRequest=805
Shows the coverage to be 79.3% after merge.

### Why did it change

Needed Sonar to report on the coverage

Note:
I have moved the sonar related checks as another github action. If it makes sense to who is reviewing I can move them to build-test-application action.