### PR TITLE
[ATB-211] - Fix 'querystring' as it is deprecated

### DIFF
--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -4,7 +4,6 @@ import { PATH_DATA, VECTORS_OF_TRUST } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { ClientAssertionServiceInterface } from "../../utils/types";
 import { clientAssertionGenerator } from "../../utils/oidc";
-import * as querystring from "querystring";
 
 const COOKIES_PREFERENCES_SET = "cookies_preferences_set";
 
@@ -109,10 +108,11 @@ export function oidcAuthCallbackGet(
         crossDomainGaIdParam &&
         req.query.cookie_consent === COOKIE_CONSENT.ACCEPT
       ) {
+        const searchParams = new URLSearchParams({ _ga: crossDomainGaIdParam });
         redirectUri =
           redirectUri +
           "?" +
-          querystring.stringify({ _ga: crossDomainGaIdParam });
+          searchParams.toString();
       }
     }
 


### PR DESCRIPTION
## Proposed changes
we use the stringify method of querystring to stringify an object and form a URL to redirect the user to. This module (querystring) is deprecated, so we are substituting it with [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).

### What changed
We are only using querystring in src/components/oidc-callback/call-back-controller.ts, as such this is the only file changed. A new URLSearchParams object is instantiated passing the object with the query param in it. The direct URL is then formed in the same way as before but we append the output of URLSearchParams.toString() method

### Why did it change
Because querystring module became deprecated

### Issue tracking
- [ATB-211](https://govukverify.atlassian.net/browse/ATB-211)

## Testing
### Local
App deployed in local docker container. Run all tests successfully 
<img width="833" alt="Screenshot 2023-02-08 at 15 51 17" src="https://user-images.githubusercontent.com/110468890/217580599-5ac349e7-f00f-4511-b3ba-d74be66943ee.png">
<img width="1084" alt="Screenshot 2023-02-08 at 15 53 45" src="https://user-images.githubusercontent.com/110468890/217581178-eadfb9c8-ad1d-41e5-ac23-a07249d75001.png">



Also inserted log line to manually check that output with querystring and output with URLSearchParams were the same, while running the unit tests for the oidc-callback component

output with querystring
![Screenshot 2023-02-08 at 14 08 24](https://user-images.githubusercontent.com/110468890/217578439-311d539c-5fee-4ccf-b2aa-0a236b7d43c5.png)

output with urlsearchparams
![Screenshot 2023-02-08 at 15 44 45](https://user-images.githubusercontent.com/110468890/217578823-2eba4046-9723-4846-b6f3-ce19ac3fcb21.png)

console log was then removed

### AWS Account
![Screenshot 2023-02-08 at 15 45 17](https://user-images.githubusercontent.com/110468890/217579022-1bdaa0e4-4ca9-4b2a-a8b9-e3b93d41b605.png)

app deployed and application manually testing by logging in and ensuring that the redirect URL (/your-services) comes up as expected
## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Other considerations
- [ ] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[ATB-211]: https://govukverify.atlassian.net/browse/ATB-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ