### PR TITLE
GUA-629 update international phone number content

### DIFF
--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -13,7 +13,7 @@ import { prependInternationalPrefix } from "../../utils/phone-number";
 import { BadRequestError } from "../../utils/errors";
 import xss from "xss";
 
-const TEMPLATE_NAME = "change-phone-number/index.njk";
+const CHANGE_PHONE_NUMBER_TEMPLATE = "change-phone-number/index.njk";
 
 export function changePhoneNumberGet(req: Request, res: Response): void {
   res.render("change-phone-number/index.njk", {
@@ -64,13 +64,18 @@ export function changePhoneNumberPost(
     }
 
     if (response.code === ERROR_CODES.NEW_PHONE_NUMBER_SAME_AS_EXISTING) {
+      
+      const href: string = (
+        hasInternationalPhoneNumber &&
+        hasInternationalPhoneNumber === "true") ? "internationalPhoneNumber" : "phoneNumber";
+
       const error = formatValidationError(
-        "phoneNumber",
+        href,
         req.t(
-          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
+          "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
         )
       );
-      return renderBadRequest(res, req, TEMPLATE_NAME, error);
+      return renderBadRequest(res, req, CHANGE_PHONE_NUMBER_TEMPLATE, error);
     } else {
       throw new BadRequestError(response.message, response.code);
     }

--- a/src/components/change-phone-number/index.njk
+++ b/src/components/change-phone-number/index.njk
@@ -18,7 +18,6 @@
   <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}" />
 
   <p class="govuk-body">{{'pages.changePhoneNumber.info.paragraph1' | translate}}</p>
-  <p class="govuk-body">{{'pages.changePhoneNumber.info.paragraph2' | translate}}</p>
 
   {{ govukInput({
   label: {

--- a/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
@@ -64,7 +64,7 @@ describe("change phone number controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_DATA.CHECK_YOUR_PHONE.url);
     });
 
-    it("should return validation error when same number", async () => {
+    it("should return validation error when same UK number", async () => {
       const fakeService: ChangePhoneNumberServiceInterface = {
         sendPhoneVerificationNotification: sandbox.fake.returns({
           success: false,
@@ -80,6 +80,25 @@ describe("change phone number controller", () => {
       expect(fakeService.sendPhoneVerificationNotification).to.have.been.called;
       expect(res.render).to.have.calledWith("change-phone-number/index.njk");
     });
+
+    it("should return validation error when same international number", async () => {
+      const fakeService: ChangePhoneNumberServiceInterface = {
+        sendPhoneVerificationNotification: sandbox.fake.returns({
+          success: false,
+          code: ERROR_CODES.NEW_PHONE_NUMBER_SAME_AS_EXISTING,
+        }),
+      };
+
+      req.session.user.tokens = { accessToken: "token" };
+      req.body.phoneNumber = "12345678991";
+      req.body.hasInternationalPhoneNumber = true;
+
+      await changePhoneNumberPost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.sendPhoneVerificationNotification).to.have.been.called;
+      expect(res.render).to.have.calledWith("change-phone-number/index.njk");
+    });
+
     it("should redirect to /phone-number-updated-confirmation when success with valid international number", async () => {
       const fakeService: ChangePhoneNumberServiceInterface = {
         sendPhoneVerificationNotification: sandbox.fake.returns({

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -111,7 +111,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK phone number"
+          "Enter a UK mobile phone number"
         );
       })
       .expect(400, done);
@@ -129,7 +129,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK phone number"
+          "Enter a UK mobile phone number"
         );
       })
       .expect(400, done);
@@ -165,7 +165,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK phone number, like 07700 900000"
+          "Enter a UK mobile phone number, like 07700 900000"
         );
       })
       .expect(400, done);
@@ -183,7 +183,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK phone number, like 07700 900000"
+          "Enter a UK mobile phone number, like 07700 900000"
         );
       })
       .expect(400, done);
@@ -278,14 +278,40 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number"
+          "Enter a mobile phone number"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
       .expect(400, done);
   });
 
-  it("should return validation error when new phone number is the same as old phone number", (done) => {
+  it("should return validation error when new international phone number entered is same as current phone number", (done) => {
+    nock(baseApi)
+        .post(API_ENDPOINTS.SEND_NOTIFICATION)
+        .once()
+        .reply(400, { code: 1044 });
+
+    request(app)
+        .post(PATH_DATA.CHANGE_PHONE_NUMBER.url)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+            _csrf: token,
+            hasInternationalPhoneNumber: true,
+            internationalPhoneNumber: "+33645453322",
+            supportInternationalNumbers: true,
+        })
+        .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($("#internationalPhoneNumber-error").text()).to.contains(
+                "You’re already using that phone number. Enter a different phone number"
+            );
+            expect($("#phoneNumber-error").text()).to.contains("");
+        })
+        .expect(400, done);
+  });
+
+  it("should return validation error when new UK phone number is the same as curent phone number", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .once()
@@ -302,7 +328,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "You are already using that phone number. Enter a different phone number."
+          "You’re already using that phone number. Enter a different phone number"
         );
       })
       .expect(400, done);
@@ -322,7 +348,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number in the correct format"
+          "Enter a mobile phone number in the correct format, including the country code"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -343,7 +369,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number using only numbers or the + symbol"
+          "Enter a mobile phone number using only numbers or the + symbol"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -358,13 +384,13 @@ describe("Integration:: change phone number", () => {
       .send({
         _csrf: token,
         hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "1234567",
+        internationalPhoneNumber: "+33123",
         supportInternationalNumbers: true,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number in the correct format"
+          "Enter a mobile phone number in the correct format, including the country code"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -379,13 +405,13 @@ describe("Integration:: change phone number", () => {
       .send({
         _csrf: token,
         hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "12345678901234567",
+        internationalPhoneNumber: "+3312345678901234567",
         supportInternationalNumbers: true,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number in the correct format"
+          "Enter a mobile phone number in the correct format, including the country code"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -489,7 +489,6 @@
       "header": "Rhowch eich rhif ffôn symudol newydd",
       "info": {
         "paragraph1": "Byddwn yn anfon cod diogelwch 6 digid i’r rhif rydych yn ei roi i ni.",
-        "paragraph2":"Mae'n rhaid i chi ddefnyddio rhif ffôn symudol y DU.",
         "backLink": "Nid wyf eisiau newid fy rhif ffôn"
       },
       "ukPhoneNumber": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -489,27 +489,27 @@
       "header": "Enter your new mobile phone number",
       "info": {
         "paragraph1": "We will send a 6 digit security code to the number you give us.",
-        "paragraph2": "You must use a UK mobile phone number.",
         "backLink": "I do not want to change my phone number"
       },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
         "validationError": {
-          "required": "Enter a UK phone number",
-          "international": "Enter a UK phone number",
-          "length": "Enter a UK phone number, like 07700 900000",
+          "required": "Enter a UK mobile phone number",
+          "international": "Enter a UK mobile phone number",
+          "length": "Enter a UK mobile phone number, like 07700 900000",
           "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol",
-          "samePhoneNumber": "You are already using that phone number. Enter a different phone number."
+          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number"
         }
       },
       "internationalPhoneNumber": {
-        "checkBoxLabel": "I have an international mobile number",
-        "label": "International mobile number",
-        "hint": "Include the country code, for example +3537777666555",
+        "checkBoxLabel": "I do not have a UK mobile number",
+        "label": "Mobile phone number",
+        "hint": "Include the country code, for example +33 for France",
         "validationError": {
-          "required": "Enter a phone number",
-          "plusNumericOnly": "Enter a phone number using only numbers or the + symbol",
-          "internationalFormat": "Enter a phone number in the correct format"
+          "required": "Enter a mobile phone number",
+          "plusNumericOnly": "Enter a mobile phone number using only numbers or the + symbol",
+          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code",
+          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number."
         }
       }
     },


### PR DESCRIPTION
## Proposed changes
[GUA-629] update international phone number content
- correct content to match designs 
- fix bug with "same number" error showing on the UK phone field when user enters current number into international number field

### What changed
- Content in Translations file 
- update template to remove lines 
- fix the href for same-number error to handle international phone number field 

### Why did it change
Updated designs and bug fixes. 

### Issue tracking
Welsh content will be updated in a later ticket. 

## Checklists
Content is OK to merge to production as IPN content is hidden by feature switch. 

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Other considerations
- [ ] Demo to a BA, TA, and the team.  << will do when testing completed 


[GUA-629]: https://govukverify.atlassian.net/browse/GUA-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ