### PR TITLE
BAU: Correct product name in Welsh

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -48,7 +48,7 @@
     },
     "header": {
       "homepageHref": "https://www.gov.uk/",
-      "productName": "Cyfrif",
+      "productName": "One Login",
       "accountLink": "Eich GOV.UK One Login",
       "accounNavHomeLink": "Eich gwasanaethau",
       "accountNavSettingsLink": "Gosodiadau",


### PR DESCRIPTION
Somehow while implementing the updates renaming the account to One Login, the product name in the header was not updated for the Welsh language version of the content. This corrects the issue.

### Before
<img width="1018" alt="Screenshot 2023-02-15 at 11 54 53" src="https://user-images.githubusercontent.com/7116819/219023185-87d8dd26-6f85-4ecb-9cf2-46a7d46c3a53.png">

### After 
<img width="894" alt="Screenshot 2023-02-15 at 12 04 33" src="https://user-images.githubusercontent.com/7116819/219023192-e12afd48-4261-417b-a878-0889be6d2f6d.png">
