### PR TITLE
GUA-517: add "How you get security codes" section

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -13,28 +13,21 @@ $govuk-new-link-styles: true;
   }
 }
 
-.accounts-summary-list {
+.summary-list-container {
   margin-bottom: govuk-spacing(7);
+  border-top: 1px solid $govuk-border-colour;
 
   .govuk-summary-list {
-    border-top: 1px solid $govuk-border-colour;
-
     @include govuk-media-query($until: "tablet") {
       padding-top: govuk-spacing(3);
     }
   }
 
-  &.accounts-summary-list--paginated {
-    margin-bottom: 0;
+}
 
-    .govuk-summary-list__row:last-of-type {
-      border-bottom: 0;
-    }
-
-    .govuk-summary-list__row:last-of-type .govuk-summary-list__key,
-    .govuk-summary-list__row:last-of-type .govuk-summary-list__value {
-      border-bottom: 0;
-    }
+.govuk-summary-list--wide-key .govuk-summary-list__key {
+  @include govuk-media-query($from: "tablet") {
+    width: 70%;
   }
 }
 

--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -2,81 +2,91 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% set pageTitleName = 'pages.manageYourAccount.title' | translate %}
 
-{% set govukSummaryListArgs =
-{
-    classes:"accounts-summary-list",
-    rows: [
-            {
-                key: {
-                    text: 'pages.manageYourAccount.summaryList.email' | translate
-                },
-                value: {
-                    text: email
-                },
-                actions: {
-                    items: [
-                        {
-                            href: "/enter-password?type=changeEmail",
-                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.email' | translate
-                        }
-                    ]
-                }
-            },
-            {
-                key: {
-                    text: 'pages.manageYourAccount.summaryList.password' | translate
-                },
-                value: {
-                    text: "••••••••••••••••"
-                },
-                actions: {
-                    items: [
-                        {
-                            href: "/enter-password?type=changePassword",
-                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.password' | translate
-                        }
-                    ]
-                }
-            }
+{% set accountDetailsSummaryList = {
+  rows: [
+    {
+      key: {
+        text: 'pages.manageYourAccount.accountDetails.summaryList.email' | translate
+      },
+      value: {
+        text: email
+      },
+      actions: {
+        items: [
+          {
+            href: "/enter-password?type=changeEmail",
+            text: 'general.change' | translate,
+            visuallyHiddenText: 'pages.manageYourAccount.accountDetails.summaryList.email' | translate
+          }
+        ]
+      }
+    },
+    {
+      key: {
+        text: 'pages.manageYourAccount.accountDetails.summaryList.password' | translate
+      },
+      value: {
+        text: "••••••••••••••••"
+      },
+      actions: {
+        items: [
+          {
+            href: "/enter-password?type=changePassword",
+            text: 'general.change' | translate,
+            visuallyHiddenText: 'pages.manageYourAccount.accountDetails.summaryList.password' | translate
+          }
+        ]
+      }
+    }
 ]} %}
-
-{% if isPhoneNumberVerified %}
-    {% set govukSummaryListArgs = (govukSummaryListArgs.rows.push(            {
-                key: {
-                    text: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
-                },
-                value: {
-                    text: phoneNumber
-                },
-                actions: {
-                    items: [
-                        {
-                            href: "/enter-password?type=changePhoneNumber",
-                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
-                        }
-                    ]
-                }
-            }), govukSummaryListArgs) %}
-{% endif %}
+{% 
+set mfaSummaryList = {
+  classes:"govuk-summary-list--wide-key",
+  rows: [{
+    key: {
+      text: 'pages.manageYourAccount.mfaSection.summaryList.phoneNumber.title' | translate | replace("[phoneNumber]", phoneNumber)
+    },
+    actions: {
+      items: [
+        {
+          href: "/enter-password?type=changePhoneNumber",
+          text: 'general.change' | translate,
+          visuallyHiddenText: 'pages.manageYourAccount.mfaSection.summaryList.phoneNumber.hiddenText' | translate
+        }
+      ]
+    }
+  }]
+}
+%}
 
 {% block content %}
-    <div class="govuk-grid-row" id="your-account">
-        <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
-            <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.manageYourAccount.header' | translate }}</h1>
-            <p class="govuk-body">{{ 'pages.manageYourAccount.signedInStatus' | translate }}
-                <strong>{{ email }}</strong>
-            </p>
-            <hr class="govuk-section-break govuk-section-break--m">
-            <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.accountDetails' | translate }}</h2>
-
-            {{ govukSummaryList(govukSummaryListArgs) }}
-
-            <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.deleteAccount.heading' | translate }}</h2>
-            <p class="govuk-body">{{ 'pages.manageYourAccount.deleteAccount.info' | translate }}</p>
-            <a href="/enter-password?type=deleteAccount" class="govuk-link govuk-body">{{ 'pages.manageYourAccount.deleteAccount.link' | translate }}</a>
-        </div>
+  <div class="govuk-grid-row" id="your-account">
+    <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+      <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.manageYourAccount.header' | translate }}</h1>
+      <p class="govuk-body">{{ 'pages.manageYourAccount.signedInStatus' | translate }}
+        <strong>{{ email }}</strong>
+      </p>
+      <hr class="govuk-section-break govuk-section-break--m">
+      <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.accountDetails.heading' | translate }}</h2>
+      <div class="summary-list-container">
+        {{ govukSummaryList(accountDetailsSummaryList) }}
+      </div>
+      <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.mfaSection.heading' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.manageYourAccount.mfaSection.paragraph' | translate }}</p>
+      <div class="summary-list-container">
+        {% if isPhoneNumberVerified %}
+          {{ govukSummaryList(mfaSummaryList) }}
+        {% else %}
+          <p class="govuk-body govuk-!-font-weight-bold govuk-!-padding-top-3"> 
+            <span class="govuk-visually-hidden">{{ 'pages.manageYourAccount.mfaSection.heading' | translate }}: </span>
+            {{ 'pages.manageYourAccount.mfaSection.summaryList.app.title' | translate }}
+          </p>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        {% endif %}
+      </div>
+      <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.deleteAccount.heading' | translate }}</h2>
+      <p class="govuk-body">{{ 'pages.manageYourAccount.deleteAccount.info' | translate }}</p>
+      <a href="/enter-password?type=deleteAccount" class="govuk-link govuk-body">{{ 'pages.manageYourAccount.deleteAccount.link' | translate }}</a>
     </div>
+  </div>
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -5,6 +5,7 @@
     "serviceNameTitle": "GOV.UK One Login",
     "errorTitlePrefix": "Gwall",
     "back": "Yn ôl",
+    "change": "Newid",
     "warning": "Rhybudd",
     "errorSummaryTitle": "Mae problem",
     "phaseBanner": {
@@ -124,12 +125,26 @@
       "title": "Gosodiadau",
       "header": "Gosodiadau",
       "signedInStatus": "Rydych wedi mewngofnodi fel",
-      "accountDetails": "Eich manylion mewngofnodi",
-      "summaryList": {
-        "email": "Cyfeiriad e-bost",
-        "password": "Cyfrinair",
-        "phoneNumber": "Rhif ffôn",
-        "changeAction": "Newid"
+      "accountDetails": {
+        "heading": "Eich manylion mewngofnodi",
+        "summaryList": {
+          "email": "Cyfeiriad e-bost",
+          "password": "Cyfrinair"
+        }
+      },
+      "mfaSection": {
+        "heading": "Sut i gael codau diogelwch",
+        "paragraph": "Rydym yn defnyddio codau diogelwch i wneud yn siwr mae chi yw chi pan fyddwch yn mewngofnodi.",
+        "summaryList": {
+          "phoneNumber": {
+            "title": "Neges testun i [phoneNumber]",
+            "hiddenText": "Rhif ffôn"
+          },
+          "app": {
+            "title": "Ap dilysydd",
+            "hiddenText": "Ap dilysydd"
+          }
+        }
       },
       "manageEmailSubscriptions": {
         "heading": "Tanysgrifiadau e-bost GOV.UK",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "serviceNameTitle": "GOV.UK One Login",
     "errorTitlePrefix": "Error",
     "back": "Back",
+    "change": "Change",
     "warning": "Warning",
     "errorSummaryTitle": "There is a problem",
     "phaseBanner": {
@@ -124,12 +125,26 @@
       "title": "Settings",
       "header": "Settings",
       "signedInStatus": "You’re signed in as",
-      "accountDetails": "Your sign in details",
-      "summaryList": {
-        "email": "Email address",
-        "password": "Password",
-        "phoneNumber": "Phone number",
-        "changeAction": "Change"
+      "accountDetails": {
+        "heading": "Your sign in details",
+        "summaryList": {
+          "email": "Email address",
+          "password": "Password"
+        }
+      },
+      "mfaSection": {
+        "heading": "How you get security codes",
+        "paragraph": "We use security codes to make sure it’s you when you sign in.",
+        "summaryList": {
+          "phoneNumber": {
+            "title": "Text message to [phoneNumber]",
+            "hiddenText": "Phone number"
+          },
+          "app": {
+            "title": "Authenticator app",
+            "hiddenText": "Authenticator app"
+          }
+        }
       },
       "manageEmailSubscriptions": {
         "heading": "GOV.UK email subscriptions",


### PR DESCRIPTION
# What
Add new "How you get security codes" section to the settings page.

# Why 
The ability to set up an account using an authenticator app for 2fa has existed for a while. 

This displays the user's current 2fa method on their account, as well as allowing the option to change the phone number if their current 2fa method is SMS. There isn't currently an option to change auth app since that functionality does not exist on the account yet. This is something we will have to iterate on in the future.

| Text  | App |
| ------------- | ------------- |
| ![Screenshot 2023-02-15 at 10 23 02](https://user-images.githubusercontent.com/7116819/219107935-588fa53f-f402-4205-a144-7be6f233b5ad.png)  | ![Screenshot 2023-02-15 at 10 22 28](https://user-images.githubusercontent.com/7116819/219107930-d8f967c1-51ff-48ed-8dd8-0baa5e585a28.png)  |



