### PR TITLE
GUA-630 welsh translation for international phone number

### DIFF
--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -72,7 +72,7 @@ export function changePhoneNumberPost(
       const error = formatValidationError(
         href,
         req.t(
-          "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
+          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
         )
       );
       return renderBadRequest(res, req, CHANGE_PHONE_NUMBER_TEMPLATE, error);

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -304,7 +304,7 @@ describe("Integration:: change phone number", () => {
         .expect(function (res) {
             const $ = cheerio.load(res.text);
             expect($("#internationalPhoneNumber-error").text()).to.contains(
-                "You’re already using that phone number. Enter a different phone number"
+                "You’re already using that phone number. Enter a different phone number."
             );
             expect($("#phoneNumber-error").text()).to.contains("");
         })
@@ -328,7 +328,7 @@ describe("Integration:: change phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "You’re already using that phone number. Enter a different phone number"
+          "You’re already using that phone number. Enter a different phone number."
         );
       })
       .expect(400, done);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -494,21 +494,21 @@
       "ukPhoneNumber": {
         "label": "Rhif ffôn symudol y DU",
         "validationError": {
-          "required": "Rhowch rif ffôn y DU",
-          "international": "Rhowch rif ffôn y DU",
-          "length": "Rhowch rif ffôn y DU, fel 07700 900000",
+          "required": "Rhowch rif ffôn symudol y DU",
+          "international": "Rhowch rif ffôn symudol y DU",
+          "length": "Rhowch rif ffôn symudol yn y DU, fel 07700 900000",
           "plusNumericOnly": "Rhowch rif ffôn symudol yn y DU gan ddefnyddio rhifau yn unig neu’r symbol +",
           "samePhoneNumber": "Rydych eisoes yn defnyddio'r rhif ffôn hwnnw. Rhowch rif ffôn gwahanol."
         }
       },
       "internationalPhoneNumber": {
-        "checkBoxLabel": "Mae gennyf rif ffôn symudol rhyngwladol",
+        "checkBoxLabel": "Rhif ffôn symudol",
         "label": "Rhif ffôn symudol rhyngwladol",
-        "hint": "Dylech gynnwys y cod gwlad, er enghraifft +3537777666555",
+        "hint": "Dylech gynnwys y cod gwlad, er enghraifft +33 am Ffrainc",
         "validationError": {
-          "required": "Rhowch rif ffôn",
-          "plusNumericOnly": "Rhowch rif ffôn gan ddefnyddio rhifau yn unig neu’r symbol +",
-          "internationalFormat": "Rhowch rif ffôn yn y ffurf cywir"
+          "required": "Rhowch rif ffôn symudol",
+          "plusNumericOnly": "Rhowch rif ffôn symudol gan ddefnyddio rhifau yn unig neu’r symbol +",
+          "internationalFormat": "Rhowch rif ffôn symudol yn y ffurf gywir, gan gynnwys y cod gwlad"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -498,7 +498,7 @@
           "international": "Enter a UK mobile phone number",
           "length": "Enter a UK mobile phone number, like 07700 900000",
           "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol",
-          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number"
+          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number."
         }
       },
       "internationalPhoneNumber": {
@@ -508,8 +508,7 @@
         "validationError": {
           "required": "Enter a mobile phone number",
           "plusNumericOnly": "Enter a mobile phone number using only numbers or the + symbol",
-          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code",
-          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number."
+          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code"
         }
       }
     },


### PR DESCRIPTION
## Proposed changes
[GUA-630] welsh translation for international phone number
also tidy english translation 

### What changed
- update welsh translations to match new english 
- adding full stop to english error message as requested by Mel 
- removed unnecessary repeat line in the english translation file 

The samePhoneNumber error is read by the controller. It only needs to appear once in the translation file for both UK and International number fields. So i've switched it to read from the UK array and removed the duplication from international errors array.    This is how it was originally set up so matches the welsh file. 


[GUA-630]: https://govukverify.atlassian.net/browse/GUA-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ