### PR TITLE
GUA-687: Adjustments to SCSS imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-ts": "tsc",
     "build": "yarn build-sass && yarn build-ts && yarn minfiy-build-js && yarn copy-assets",
     "build-dev": "yarn build-sass && yarn build-ts && yarn copy-assets",
-    "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/style.css --style compressed",
+    "build-sass": "rm -rf dist/public/style.css && sass --load-path=node_modules/govuk-frontend/govuk --no-source-map src/assets/scss/application.scss dist/public/style.css --style compressed",
     "clean": "rm -rf dist node_modules logs.json",
     "clean-modules": "rm -rf node_modules",
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts -e **/all.js && cp node_modules/govuk-frontend/govuk/all.js dist/public/scripts",
@@ -26,7 +26,7 @@
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test:unit",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
-    "watch-sass": "sass --watch src/assets/scss/application.scss dist/public/style.css"
+    "watch-sass": "sass --load-path=node_modules/govuk-frontend/govuk --watch src/assets/scss/application.scss dist/public/style.css"
   },
   "mocha": {
     "diff": true,

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -1,6 +1,27 @@
 $govuk-new-link-styles: true;
 
-@import "../../../node_modules/govuk-frontend/govuk/all";
+@import "base";
+@import "core/all";
+@import "utilities/all";
+@import "objects/all";
+@import "overrides/all";
+
+// start Design System component imports
+@import "components/back-link/back-link";
+@import "components/button/button";
+@import "components/checkboxes/checkboxes";
+@import "components/cookie-banner/cookie-banner";
+@import "components/details/details";
+@import "components/error-summary/error-summary";
+@import "components/footer/footer";
+@import "components/header/header";
+@import "components/input/input";
+@import "components/inset-text/inset-text";
+@import "components/panel/panel";
+@import "components/phase-banner/phase-banner";
+@import "components/skip-link/skip-link";
+@import "components/summary-list/summary-list";
+// end Design System component imports
 
 .information-box {
   margin-bottom: govuk-spacing(4);


### PR DESCRIPTION
### What

1. Optimise scss imports from the DS npm module so that only styles for components being used in the application are imported. Previously we were indiscriminately importing all styles including for components which are not currently used in the account management app.

2. Add load path to sass so that DS `scss` imports automatically resolve to their location in `node_modules`.


- [GUA-687](https://govukverify.atlassian.net/browse/GUA-687)

### Why
1. reduces unused CSS (128 kB -> 89.8 kB) and should marginally improve our performance score
2. makes our code nicer
<!-- Describe the reason these changes were made - the "why" -->




[GUA-687]: https://govukverify.atlassian.net/browse/GUA-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ