### PR TITLE
ATB-342 Remove the actions to execute when alarm transitions to the OK state from any other state

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -98,6 +98,7 @@ Parameters:
 
 Conditions:
   IsNotDevelopment: !Or
+    - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -98,7 +98,6 @@ Parameters:
 
 Conditions:
   IsNotDevelopment: !Or
-    - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1451,8 +1451,6 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
-      OKActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
@@ -1500,8 +1498,6 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
-      OKActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
@@ -1548,8 +1544,6 @@ Resources:
       AlarmDescription: "Trigger the alarm if response latency exceeds 2.5 seconds with the minimum of 10 invocations in 2 out of the last 5 minutes"
       ActionsEnabled: true
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
-      OKActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 5


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[ATB-XXXX] PR Title` -->

### What changed

Remove the actions to execute when API Gateway 5xx, 4xx, and Latency alarms transition to the OK state from any other state. We will now only receive slack notifications when the above alarms transition into an in `Alarm` state. 

### Why did it change

This has been flooding our slack notifications channel and does not provide much value.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-342](https://govukverify.atlassian.net/browse/ATB-342)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Other considerations
- [ ] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[ATB-342]: https://govukverify.atlassian.net/browse/ATB-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ