### PR TITLE
GUA-660: Add mortgage deed to service list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -144,9 +144,11 @@ export const getAllowedServiceListClientIDs: string[] = [
   "Dw7Cxas8W7O2usHMHok95elKDRU",
   "oLciSn5b6-cqcJjzgMMwCw1moD8",
   "LUIZbIuJ_xVZxwhkNAApcO4O_6o",
+  "VsAkrtMBzAosSveAv4xsuUDyiSs",
   "socialWorkEngland",
   "dbs",
   "vehicleOperatorLicense",
+  "mortgageDeed",
 ];
 
 function getProtocol(): string {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -205,6 +205,10 @@
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "VsAkrtMBzAosSveAv4xsuUDyiSs": {
+            "link_text": "Llofnodwch eich gweithred morgais",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "integration": {
@@ -231,6 +235,10 @@
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "VsAkrtMBzAosSveAv4xsuUDyiSs": {
+            "link_text": "Llofnodwch eich gweithred morgais",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "staging": {
@@ -257,6 +265,10 @@
           "socialWorkEngland": {
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Llofnodwch eich gweithred morgais",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "build": {
@@ -283,6 +295,10 @@
           "socialWorkEngland": {
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Llofnodwch eich gweithred morgais",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "dev": {
@@ -309,6 +325,10 @@
           "socialWorkEngland": {
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Llofnodwch eich gweithred morgais",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "local": {
@@ -335,6 +355,10 @@
           "socialWorkEngland": {
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Llofnodwch eich gweithred morgais",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         }
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -205,6 +205,10 @@
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "VsAkrtMBzAosSveAv4xsuUDyiSs": {
+            "link_text": "Sign your mortgage deed",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "integration": {
@@ -231,6 +235,10 @@
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "VsAkrtMBzAosSveAv4xsuUDyiSs": {
+            "link_text": "Sign your mortgage deed",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "staging": {
@@ -257,6 +265,10 @@
           "socialWorkEngland": {
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Sign your mortgage deed",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "build": {
@@ -283,6 +295,10 @@
           "socialWorkEngland": {
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Sign your mortgage deed",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "dev": {
@@ -309,6 +325,10 @@
           "socialWorkEngland": {
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Sign your mortgage deed",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         },
         "local": {
@@ -335,6 +355,10 @@
           "socialWorkEngland": {
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+          },
+          "mortgageDeed": {
+            "link_text": "Sign your mortgage deed",
+            "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
         }
       }


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/GUA-660

Add the capability to have the "Sign your mortgage deed" card under "Other services you've used" on the "Your services" page.

This new card would not actually appear until the service has been onboarded (due to happen Monday morning 8am).

Content (such as updates to the account blurb) will be added in a separate PR. This PR can go forward at any point, whereas other content should probably go live at the same time as the service (or roughly at the same time)

![Screenshot 2023-02-24 at 16 23 37](https://user-images.githubusercontent.com/7116819/221232129-0d539c3f-6b41-447c-87bd-7ff4e525fab4.png)


[Figma for reference](https://www.figma.com/file/0JbNRTnq5ibRtfg8BMxXDL/Accounts-design-thinking?node-id=1252%3A13237&t=86knNaxy6x8Yht8k-0)