### PR TITLE
ATB-353 Disable CloudWatch alarm actions until new thresholds are defined

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1448,7 +1448,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGateway4xxStatusAlarm"
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -1495,7 +1495,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGateway5xxStatusAlarm"
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -1542,7 +1542,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGatewayLatencyAlarm"
       AlarmDescription: "Trigger the alarm if response latency exceeds 2.5 seconds with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: true
+      ActionsEnabled: false
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanThreshold


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[ATB-XXXX] PR Title` -->

### What changed

This PR disables all actions triggered by CloudWatch alarms until new thresholds are defined and tested.

### Why did it change

Our first iteration of API Gateway alarms seem to be too sensitive and as a result have flooded our slack notifications channel.

### Testing
Alarm actions have been disabled.
![Screenshot 2023-02-27 at 10 38 23](https://user-images.githubusercontent.com/110469146/221548517-6556f3e4-a148-4a11-b174-cdfac392119a.png)
![Screenshot 2023-02-27 at 10 38 16](https://user-images.githubusercontent.com/110469146/221548525-c103bbcd-ded0-4bfc-8c4e-578d80a1274b.png)
![Screenshot 2023-02-27 at 10 38 30](https://user-images.githubusercontent.com/110469146/221548531-e8f660d1-4190-4326-86e3-1425ecb1c17e.png)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [ATB-353](https://govukverify.atlassian.net/browse/ATB-353)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Other considerations
- [ ] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[ATB-353]: https://govukverify.atlassian.net/browse/ATB-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ