### PR TITLE
GUA - 593 customise delete screen 

### DIFF
--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -15,11 +15,10 @@ import {
 } from "../../config";
 
 import { destroyUserSessions } from "../../utils/session-store";
-import {
-  getServices,
-  containsGovUkPublishingService,
-} from "../../utils/yourServices";
+
+import { containsGovUkPublishingService } from "../../utils/yourServices";
 import { Service } from "../../utils/types";
+import { getAllowedListServices } from "../../utils/yourServices";
 
 export async function deleteAccountGet(
   req: Request,
@@ -28,7 +27,7 @@ export async function deleteAccountGet(
   const env = getAppEnv();
   const { user } = req.session;
   if (user && user.subjectId) {
-    const services: Service[] = await getServices(user.subjectId);
+    const services: Service[] = await getAllowedListServices(user.subjectId);
     const hasGovUkEmailSubscription: boolean =
       containsGovUkPublishingService(services);
     const data = {

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -24,7 +24,7 @@
     {% endfor %}
     </ul>
     {% if hasGovUkEmailSubscription %}
-    <p class="govuk-body" id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
+      <p class="govuk-body" id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
     {% endif %}
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph4b' | translate }}</p>
   {% endif %}

--- a/src/components/delete-account/tests/delete-account-controller.test.ts
+++ b/src/components/delete-account/tests/delete-account-controller.test.ts
@@ -55,9 +55,7 @@ describe("delete account controller", () => {
   });
 
   describe("deleteAccountGet", () => {
-
     it("deleteAccountGetWithoutSubjectId", () => {
-
       it("should render delete account page", () => {
         const req: any = {
           body: {},
@@ -76,21 +74,19 @@ describe("delete account controller", () => {
     });
 
     it("deleteAccountGetWithoutServices", () => {
-
       it("should render delete account page", () => {
-        const serviceList: Service[] = [];
         req = validRequest();
         const yourServices = require("../../../utils/yourServices");
         sandbox
-          .stub(yourServices, "getServices")
+          .stub(yourServices, "getAllowedListServices")
           .callsFake(function (): Service[] {
-            return serviceList;
+            return [];
           });
-          
+
         deleteAccountGet(req as Request, res as Response);
         expect(res.render).to.have.calledWith("delete-account/index.njk", {
           manageEmailsLink: "https://www.gov.uk/email/manage",
-          servicesList: serviceList,
+          servicesList: [],
           env: getAppEnv(),
         });
       });
@@ -105,12 +101,12 @@ describe("delete account controller", () => {
           last_accessed_readable_format: "last_accessed_readable_format",
         },
       ];
-      
+
       it("should render the delete account page with list of services used", () => {
         req = validRequest();
         const yourServices = require("../../../utils/yourServices");
         sandbox
-          .stub(yourServices, "getServices")
+          .stub(yourServices, "getAllowedListServices")
           .callsFake(function (): Service[] {
             return serviceList;
           });
@@ -127,7 +123,6 @@ describe("delete account controller", () => {
 
   describe("deleteAccountPost", () => {
     describe("when not supporting DELETE_SERVICE_STORE", () => {
-
       beforeEach(() => {
         process.env.SUPPORT_DELETE_SERVICE_STORE = "0";
       });

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -45,7 +45,7 @@ describe("Integration:: delete account", () => {
     },
   ];
 
-  function stubGetServicesToReturn(serviceList: Service[]) {
+  function stubGetAllowedListServicesToReturn(serviceList: Service[]) {
     yourServicesStub.callsFake(function (): Service[] {
       return serviceList;
     });
@@ -57,7 +57,7 @@ describe("Integration:: delete account", () => {
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
     const yourServices = require("../../../utils/yourServices");
     sandbox = sinon.createSandbox();
-    yourServicesStub = sandbox.stub(yourServices, "getServices");
+    yourServicesStub = sandbox.stub(yourServices, "getAllowedListServices");
     sandbox
       .stub(sessionMiddleware, "requiresAuthMiddleware")
       .callsFake(function (req: any, res: any, next: any): void {
@@ -136,12 +136,12 @@ describe("Integration:: delete account", () => {
   });
 
   it("should return delete account page", (done) => {
-    stubGetServicesToReturn(aSingleService);
+    stubGetAllowedListServicesToReturn(aSingleService);
     request(app).get(PATH_DATA.DELETE_ACCOUNT.url).expect(200, done);
   });
 
   it("should display generic content if no services exist", (done) => {
-    stubGetServicesToReturn([]);
+    stubGetAllowedListServicesToReturn([]);
 
     request(app)
       .get(PATH_DATA.DELETE_ACCOUNT.url)
@@ -155,7 +155,7 @@ describe("Integration:: delete account", () => {
   });
 
   it("should display GovUk subscription info if publishing service exists", (done) => {
-    stubGetServicesToReturn(manyServicesIncludingGovUkPublishing);
+    stubGetAllowedListServicesToReturn(manyServicesIncludingGovUkPublishing);
 
     request(app)
       .get(PATH_DATA.DELETE_ACCOUNT.url)
@@ -168,7 +168,7 @@ describe("Integration:: delete account", () => {
   });
 
   it("should not display subscription info if publishing service does not exists", (done) => {
-    stubGetServicesToReturn(aSingleService);
+    stubGetAllowedListServicesToReturn(aSingleService);
 
     request(app)
       .get(PATH_DATA.DELETE_ACCOUNT.url)

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -330,7 +330,7 @@
             "link_href": "https://exporter.lite.private-beta.service.trade.gov.uk/"
           },
           "dbs": {
-             "header": "Request a basic DBS check",
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -21,7 +21,7 @@ const serviceStoreDynamoDBRequest = (
 const unmarshallDynamoData = (dynamoDBResponse: DynamoDB.Types.AttributeMap) =>
   DynamoDB.Converter.unmarshall(dynamoDBResponse);
 
-export const getServices = async (subjectId: string): Promise<Service[]> => {
+const getServices = async (subjectId: string): Promise<Service[]> => {
   const logger = pino();
   try {
     const response = await dynamoDBService().getItem(
@@ -55,6 +55,22 @@ export const presentYourServices = async (
       accountsList: [],
       servicesList: [],
     };
+  }
+};
+
+export const getAllowedListServices = async (
+  subjectId: string
+): Promise<Service[]> => {
+  const userServices = await getServices(subjectId);
+  if (userServices) {
+    return userServices.filter((service) => {
+      return (
+        getAllowedAccountListClientIDs.includes(service.client_id) ||
+        getAllowedServiceListClientIDs.includes(service.client_id)
+      );
+    });
+  } else {
+    return [];
   }
 };
 

--- a/test/unit/utils/yourServices.test.ts
+++ b/test/unit/utils/yourServices.test.ts
@@ -1,53 +1,55 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { formatService, containsGovUkPublishingService } from "../../../src/utils/yourServices"
+import {
+  formatService,
+  containsGovUkPublishingService,
+} from "../../../src/utils/yourServices";
 import type { Service } from "../../../src/utils/types";
 
 describe("YourService Util", () => {
-    describe("format service information to diplay", () => {
-        it("It takes a date epoch in seconds and returns a pretty formatted date", async () => {
-            const dateEpochInSeconds = 1673358736;
-            const serviceFromDb: Service = {
-                client_id : "a_client_id",
-                count_successful_logins : 1,
-                last_accessed : dateEpochInSeconds,
-                last_accessed_readable_format : undefined
-            }
-    
-            const formattedService: Service = formatService(serviceFromDb);
-    
-            expect(formattedService.client_id).equal("a_client_id");
-            expect(formattedService.count_successful_logins).equal(1);
-            expect(formattedService.last_accessed_readable_format).equal("10 January 2023");
-          });
-    
-    })
+  describe("format service information to diplay", () => {
+    it("It takes a date epoch in seconds and returns a pretty formatted date", async () => {
+      const dateEpochInSeconds = 1673358736;
+      const serviceFromDb: Service = {
+        client_id: "a_client_id",
+        count_successful_logins: 1,
+        last_accessed: dateEpochInSeconds,
+        last_accessed_readable_format: undefined,
+      };
 
-    describe("does GovUK Publishing service exist in array", async () => {
+      const formattedService: Service = formatService(serviceFromDb);
 
-        it("return false if array does not contain govUK publishing service", () => {
-            const serviceList: Service[] = [
-                {
-                  client_id: "client_id",
-                  count_successful_logins: 1,
-                  last_accessed: 14567776,
-                  last_accessed_readable_format: "last_accessed_readable_format",
-                },
-              ];
-            expect(containsGovUkPublishingService(serviceList)).equal(false);
-        })
+      expect(formattedService.client_id).equal("a_client_id");
+      expect(formattedService.count_successful_logins).equal(1);
+      expect(formattedService.last_accessed_readable_format).equal(
+        "10 January 2023"
+      );
+    });
+  });
 
-        it("return true if array contains govUK publishing service", () => {
-            const serviceList: Service[] = [
-                {
-                  client_id: "gov-uk",
-                  count_successful_logins: 1,
-                  last_accessed: 14567776,
-                  last_accessed_readable_format: "last_accessed_readable_format",
-                },
-              ];
-            expect(containsGovUkPublishingService(serviceList)).equal(true);
-        })
-    })
-})
- 
+  describe("does GovUK Publishing service exist in array", async () => {
+    it("return false if array does not contain govUK publishing service", () => {
+      const serviceList: Service[] = [
+        {
+          client_id: "client_id",
+          count_successful_logins: 1,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
+      ];
+      expect(containsGovUkPublishingService(serviceList)).equal(false);
+    });
+
+    it("return true if array contains govUK publishing service", () => {
+      const serviceList: Service[] = [
+        {
+          client_id: "gov-uk",
+          count_successful_logins: 1,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
+      ];
+      expect(containsGovUkPublishingService(serviceList)).equal(true);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes
GUA-593 : Add personalisation to the Delete screen including the services used.

### What changed

- Adjusted the delete controller to read from dynamo db similar to your-services. 
- Personalise content on the screen based on what services user has.
- Add additional unit and integration tests.

Delete screen with email subscriptions.

![Delete_GOVUK](https://user-images.githubusercontent.com/17740808/221894102-8036fac6-896f-4f9c-86ec-f3e88982eae7.png)

Delete without GOVUK subscriptions

<img width="1404" alt="Delete_withoutGOVUK" src="https://user-images.githubusercontent.com/17740808/221911586-9ba81407-0e06-4836-8616-a15133ab0f1b.png">
