### PR TITLE
Gua 593 customise delete screen fix rebased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,6 +2807,7 @@
     "node_modules/aws-sdk/node_modules/uuid": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -2888,6 +2889,7 @@
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -2919,6 +2921,7 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/body-parser/node_modules/on-finished": {
@@ -2943,13 +2946,8 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
-    },
-    "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4424,6 +4422,7 @@
     "node_modules/express-session/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -4440,6 +4439,7 @@
     "node_modules/express-session/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/express-validator": {
@@ -4477,6 +4477,7 @@
     "node_modules/express/node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4485,6 +4486,7 @@
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -4493,6 +4495,7 @@
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/qs": {
@@ -4659,6 +4662,7 @@
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -4667,6 +4671,7 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/find-cache-dir": {
@@ -7492,6 +7497,7 @@
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -7500,6 +7506,7 @@
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/send/node_modules/destroy": {

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -6,13 +6,45 @@ import { PATH_DATA } from "../../app.constants";
 import { getNextState } from "../../utils/state-machine";
 import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/types";
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
-import { getBaseUrl, getManageGovukEmailsUrl, getSNSDeleteTopic, supportDeleteServiceStore } from "../../config";
-import { destroyUserSessions } from "../../utils/session-store";
+import {
+  getAppEnv,
+  getBaseUrl,
+  getManageGovukEmailsUrl,
+  supportDeleteServiceStore,
+  getSNSDeleteTopic,
+} from "../../config";
 
-export function deleteAccountGet(req: Request, res: Response): void {
-  res.render("delete-account/index.njk", {
-    manageEmailsLink: getManageGovukEmailsUrl(),
-  });
+import { destroyUserSessions } from "../../utils/session-store";
+import {
+  getServices,
+  containsGovUkPublishingService,
+} from "../../utils/yourServices";
+import { Service } from "../../utils/types";
+
+export async function deleteAccountGet(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const env = getAppEnv();
+  const { user } = req.session;
+  if (user && user.subjectId) {
+    const services: Service[] = await getServices(user.subjectId);
+    const hasGovUkEmailSubscription: boolean =
+      containsGovUkPublishingService(services);
+    const data = {
+      hasGovUkEmailSubscription: hasGovUkEmailSubscription,
+      services: services,
+      env: env,
+      manageEmailsLink: getManageGovukEmailsUrl(),
+    };
+    res.render("delete-account/index.njk", data);
+  } else {
+    const data = {
+      env: env,
+      manageEmailsLink: getManageGovukEmailsUrl(),
+    };
+    res.render("delete-account/index.njk", data);
+  }
 }
 
 export function deleteAccountPost(
@@ -25,11 +57,13 @@ export function deleteAccountPost(
     const { accessToken } = req.session.user.tokens;
 
     if (supportDeleteServiceStore()) {
-      const DeleteTopicARN = getSNSDeleteTopic()
+      const DeleteTopicARN = getSNSDeleteTopic();
       try {
-        await service.deleteServiceData(subjectId, DeleteTopicARN)
+        await service.deleteServiceData(subjectId, DeleteTopicARN);
       } catch (err) {
-        req.log.error(`Unable to publish delete topic message for: ${subjectId} and ARN ${DeleteTopicARN}. Error:${err}`)
+        req.log.error(
+          `Unable to publish delete topic message for: ${subjectId} and ARN ${DeleteTopicARN}. Error:${err}`
+        );
       }
     }
 

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -15,11 +15,10 @@ import {
 } from "../../config";
 
 import { destroyUserSessions } from "../../utils/session-store";
-import {
-  getServices,
-  containsGovUkPublishingService,
-} from "../../utils/yourServices";
+
+import { containsGovUkPublishingService } from "../../utils/yourServices";
 import { Service } from "../../utils/types";
+import { getAllowedListServices } from "../../utils/yourServices";
 
 export async function deleteAccountGet(
   req: Request,
@@ -28,7 +27,7 @@ export async function deleteAccountGet(
   const env = getAppEnv();
   const { user } = req.session;
   if (user && user.subjectId) {
-    const services: Service[] = await getServices(user.subjectId);
+    const services: Service[] = await getAllowedListServices(user.subjectId);
     const hasGovUkEmailSubscription: boolean =
       containsGovUkPublishingService(services);
     const data = {

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -12,13 +12,26 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0">{{'pages.deleteAccount.header' | translate}}</h1>
 
 <p class="govuk-body">{{'pages.deleteAccount.paragraph1' | translate}}</p>
-<p class="govuk-body">{{ 'pages.deleteAccount.paragraph2' | translate }}</p>
-<p class="govuk-body">{{ 'pages.deleteAccount.paragraph3' 
-    | translate
-    | replace("[emailManagementLink]", manageEmailsLink)
-    | safe
-    }}</p>
-<p class="govuk-body">{{ 'pages.deleteAccount.paragraph4' | translate }}</p>
+
+ {% if services.length %}
+  <p class="govuk-body">{{ 'pages.deleteAccount.paragraph2' | translate }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    {% for service in services %}
+
+      {% set locale = ['pages.yourServices.clientRegistry.', env, '.', service.client_id, '.'] | join %}
+        <li id="service-list-item">{{ [locale, 'header'] | join | translate }}</li>
+
+    {% endfor %}
+    </ul>
+    {% if hasGovUkEmailSubscription %}
+    <p class="govuk-body" id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
+    {% endif %}
+  <p class="govuk-body">{{ 'pages.deleteAccount.paragraph4b' | translate }}</p>
+  {% endif %}
+
+  {% if not services.length %}
+<p class="govuk-body", id="no-services-content">{{ 'pages.deleteAccount.paragraph4a' | translate }}</p>
+ {% endif %}
 <p class="govuk-body">{{ 'pages.deleteAccount.paragraph5' | translate }}</p>
 
 {{ govukInsetText({

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -24,7 +24,7 @@
     {% endfor %}
     </ul>
     {% if hasGovUkEmailSubscription %}
-    <p class="govuk-body" id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
+      <p class="govuk-body" id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
     {% endif %}
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph4b' | translate }}</p>
   {% endif %}

--- a/src/components/delete-account/tests/delete-account-controller.test.ts
+++ b/src/components/delete-account/tests/delete-account-controller.test.ts
@@ -57,7 +57,6 @@ describe("delete account controller", () => {
   describe("deleteAccountGet", () => {
 
     it("deleteAccountGetWithoutSubjectId", () => {
-
       it("should render delete account page", () => {
         const req: any = {
           body: {},
@@ -76,21 +75,17 @@ describe("delete account controller", () => {
     });
 
     it("deleteAccountGetWithoutServices", () => {
-
       it("should render delete account page", () => {
-        const serviceList: Service[] = [];
         req = validRequest();
         const yourServices = require("../../../utils/yourServices");
         sandbox
-          .stub(yourServices, "getServices")
-          .callsFake(function (): Service[] {
-            return serviceList;
-          });
-          
+          .stub(yourServices, "getAllowedListServices")
+          .callsFake(function (): Service[] { return []; });
+
         deleteAccountGet(req as Request, res as Response);
         expect(res.render).to.have.calledWith("delete-account/index.njk", {
           manageEmailsLink: "https://www.gov.uk/email/manage",
-          servicesList: serviceList,
+          servicesList: [],
           env: getAppEnv(),
         });
       });
@@ -105,12 +100,12 @@ describe("delete account controller", () => {
           last_accessed_readable_format: "last_accessed_readable_format",
         },
       ];
-      
+
       it("should render the delete account page with list of services used", () => {
         req = validRequest();
         const yourServices = require("../../../utils/yourServices");
         sandbox
-          .stub(yourServices, "getServices")
+          .stub(yourServices, "getAllowedListServices")
           .callsFake(function (): Service[] {
             return serviceList;
           });
@@ -126,8 +121,8 @@ describe("delete account controller", () => {
   });
 
   describe("deleteAccountPost", () => {
-    describe("when not supporting DELETE_SERVICE_STORE", () => {
 
+    describe("when not supporting DELETE_SERVICE_STORE", () => {
       beforeEach(() => {
         process.env.SUPPORT_DELETE_SERVICE_STORE = "0";
       });

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -45,7 +45,7 @@ describe("Integration:: delete account", () => {
     },
   ];
 
-  function stubGetServicesToReturn(serviceList: Service[]) {
+  function stubGetAllowedListServicesToReturn(serviceList: Service[]) {
     yourServicesStub.callsFake(function (): Service[] {
       return serviceList;
     });
@@ -57,7 +57,7 @@ describe("Integration:: delete account", () => {
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
     const yourServices = require("../../../utils/yourServices");
     sandbox = sinon.createSandbox();
-    yourServicesStub = sandbox.stub(yourServices, "getServices");
+    yourServicesStub = sandbox.stub(yourServices, "getAllowedListServices");
     sandbox
       .stub(sessionMiddleware, "requiresAuthMiddleware")
       .callsFake(function (req: any, res: any, next: any): void {
@@ -136,12 +136,12 @@ describe("Integration:: delete account", () => {
   });
 
   it("should return delete account page", (done) => {
-    stubGetServicesToReturn(aSingleService);
+    stubGetAllowedListServicesToReturn(aSingleService);
     request(app).get(PATH_DATA.DELETE_ACCOUNT.url).expect(200, done);
   });
 
   it("should display generic content if no services exist", (done) => {
-    stubGetServicesToReturn([]);
+    stubGetAllowedListServicesToReturn([]);
 
     request(app)
       .get(PATH_DATA.DELETE_ACCOUNT.url)
@@ -155,7 +155,7 @@ describe("Integration:: delete account", () => {
   });
 
   it("should display GovUk subscription info if publishing service exists", (done) => {
-    stubGetServicesToReturn(manyServicesIncludingGovUkPublishing);
+    stubGetAllowedListServicesToReturn(manyServicesIncludingGovUkPublishing);
 
     request(app)
       .get(PATH_DATA.DELETE_ACCOUNT.url)
@@ -168,7 +168,7 @@ describe("Integration:: delete account", () => {
   });
 
   it("should not display subscription info if publishing service does not exists", (done) => {
-    stubGetServicesToReturn(aSingleService);
+    stubGetAllowedListServicesToReturn(aSingleService);
 
     request(app)
       .get(PATH_DATA.DELETE_ACCOUNT.url)

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -1,12 +1,14 @@
 import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
 import { API_ENDPOINTS, PATH_DATA } from "../../../app.constants";
 import { UnsecuredJWT } from "jose";
 import { getBaseUrl } from "../../../config";
+import { Service } from "../../../utils/types";
+import { SinonStub } from "sinon";
 
 describe("Integration:: delete account", () => {
   let sandbox: sinon.SinonSandbox;
@@ -15,14 +17,47 @@ describe("Integration:: delete account", () => {
   let app: any;
   let baseApi: string;
   let govUkPublishingBaseApi: string;
+  let yourServicesStub: SinonStub<any[], any>;
   const idToken = "Idtoken";
   const TEST_SUBJECT_ID = "sub";
+
+  const aSingleService: Service[] = [
+    {
+      client_id: "client_id",
+      count_successful_logins: 1,
+      last_accessed: 14567776,
+      last_accessed_readable_format: "last_accessed_readable_format",
+    },
+  ];
+
+  const manyServicesIncludingGovUkPublishing: Service[] = [
+    {
+      client_id: "client_id",
+      count_successful_logins: 1,
+      last_accessed: 14567776,
+      last_accessed_readable_format: "last_accessed_readable_format",
+    },
+    {
+      client_id: "gov-uk",
+      count_successful_logins: 2,
+      last_accessed: 14567776,
+      last_accessed_readable_format: "last_accessed_readable_format",
+    },
+  ];
+
+  function stubGetServicesToReturn(serviceList: Service[]) {
+    yourServicesStub.callsFake(function (): Service[] {
+      return serviceList;
+    });
+  }
 
   before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
+    const yourServices = require("../../../utils/yourServices");
     sandbox = sinon.createSandbox();
+    yourServicesStub = sandbox.stub(yourServices, "getServices");
     sandbox
       .stub(sessionMiddleware, "requiresAuthMiddleware")
       .callsFake(function (req: any, res: any, next: any): void {
@@ -91,23 +126,68 @@ describe("Integration:: delete account", () => {
     nock.cleanAll();
   });
 
+  afterEach(() => {
+    yourServicesStub.reset();
+  });
+
   after(() => {
     sandbox.restore();
     app = undefined;
   });
 
   it("should return delete account page", (done) => {
+    stubGetServicesToReturn(aSingleService);
     request(app).get(PATH_DATA.DELETE_ACCOUNT.url).expect(200, done);
   });
 
-  it("should return error when csrf not present", (done) => {
+  it("should display generic content if no services exist", (done) => {
+    stubGetServicesToReturn([]);
+
+    request(app)
+      .get(PATH_DATA.DELETE_ACCOUNT.url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#no-services-content").text()).to.not.be.empty;
+        expect($("#govuk-email-subscription-info").text()).to.be.empty;
+        expect($("#service-list-item").text()).to.be.empty;
+      })
+      .expect(200, done);
+  });
+
+  it("should display GovUk subscription info if publishing service exists", (done) => {
+    stubGetServicesToReturn(manyServicesIncludingGovUkPublishing);
+
+    request(app)
+      .get(PATH_DATA.DELETE_ACCOUNT.url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#govuk-email-subscription-info").text()).to.not.be.empty;
+        expect($("#service-list-item").text()).to.not.be.empty;
+      })
+      .expect(200, done);
+  });
+
+  it("should not display subscription info if publishing service does not exists", (done) => {
+    stubGetServicesToReturn(aSingleService);
+
+    request(app)
+      .get(PATH_DATA.DELETE_ACCOUNT.url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#service-list-item").text()).to.not.be.empty;
+        expect($("#govuk-email-subscription-info").text()).to.be.empty;
+      })
+      .expect(200, done);
+  });
+
+  it("post should return error when csrf not present", (done) => {
     request(app)
       .post(PATH_DATA.DELETE_ACCOUNT.url)
       .type("form")
       .expect(500, done);
   });
 
-  it("should redirect to end session endpoint", (done) => {
+  it("post should redirect to end session endpoint", (done) => {
     nock(baseApi).post(API_ENDPOINTS.DELETE_ACCOUNT).once().reply(204);
     nock(govUkPublishingBaseApi)
       .delete(`${API_ENDPOINTS.ALPHA_GOV_ACCOUNT}${TEST_SUBJECT_ID}`)

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -257,6 +257,7 @@
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "VsAkrtMBzAosSveAv4xsuUDyiSs": {
+            "header": "Llofnodwch eich gweithred morgais",
             "link_text": "Llofnodwch eich gweithred morgais",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -203,14 +203,17 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "RqFZ83csmS4Mi4Y7s7ohD9-ekwU": {
+            "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "XwwVDyl5oJKtK0DVsuw3sICWkPU": {
+            "header": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_text": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
+            "header": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
@@ -239,14 +242,17 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "Dw7Cxas8W7O2usHMHok95elKDRU": {
+            "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "oLciSn5b6-cqcJjzgMMwCw1moD8": {
+            "header": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_text": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
+            "header": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
@@ -275,18 +281,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_text": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Llofnodwch eich gweithred morgais",
             "link_text": "Llofnodwch eich gweithred morgais",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -311,18 +321,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_text": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Llofnodwch eich gweithred morgais",
             "link_text": "Llofnodwch eich gweithred morgais",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -347,18 +361,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_text": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Llofnodwch eich gweithred morgais",
             "link_text": "Llofnodwch eich gweithred morgais",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -383,18 +401,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_text": "Gwneud cais am drwydded gweithredwr cerbyd",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Llofnodwch eich gweithred morgais",
             "link_text": "Llofnodwch eich gweithred morgais",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -553,9 +575,10 @@
       "title": "Ydych chi'n siwr eich bod eisiau dileu eich GOV.UK One Login?",
       "header": "Ydych chi'n siwr eich bod eisiau dileu eich GOV.UK One Login?",
       "paragraph1": "Bydd hyn yn dileu eich manylion mewngofnodi GOV.UK One Login yn barhaol.",
-      "paragraph2": "Mae hyn yn golygu na fyddwch bellach yn gallu cael mynediad i'r gwasanaethau rydych yn eu defnyddio gyda'ch GOV.UK One Login.",
-      "paragraph3": "Os oes gennych <a class=\"govuk-link\" href=\"[emailManagementLink]\">danysgrifiadau e-byst GOV.UK</a>, bydd y rhain hefyd yn cael eu dileu.",
-      "paragraph4": "Ni fydd yn dileu'r wybodaeth bersonol a gedwir gan wasanaethau rydych wedi'u defnyddio gyda'ch GOV.UK One Login.",
+      "paragraph2": "Ni fyddwch bellach yn gallu mewngofnodi i ddefnyddio:",
+      "paragraph3": "Bydd hyn hefyd yn dileu eich tanysgrifiadau e-bost GOV.UK.",
+      "paragraph4a": "Ni fydd yn dileu'r wybodaeth bersonol a gedwir gan wasanaethau rydych wedi'u defnyddio gyda'ch GOV.UK One Login.",
+      "paragraph4b": "Ni fydd yn dileu'r wybodaeth bersonol a gedwir gan wasanaethau rydych wedi'u defnyddio.",
       "paragraph5": "Os byddwch angen GOV.UK One Login yn y dyfodol, bydd yn rhaid i chi greu un newydd.",
       "details": "Ni fydd dileu eich GOV.UK One Login yn effeithio ar unrhyw gyfrifon eraill y llywodraeth sydd gennych, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
       "deleteAccount": "Dileu eich GOV.UK One Login",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -257,6 +257,7 @@
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "VsAkrtMBzAosSveAv4xsuUDyiSs": {
+            "header": "Sign your mortgage deed",
             "link_text": "Sign your mortgage deed",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -361,7 +362,7 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
-             "header": "Request a basic DBS check",
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -203,14 +203,17 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "RqFZ83csmS4Mi4Y7s7ohD9-ekwU": {
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "XwwVDyl5oJKtK0DVsuw3sICWkPU": {
+            "header": "Apply for a vehicle operator licence",
             "link_text": "Apply for a vehicle operator licence",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
+            "header": "Apply to become a registered social worker in England",
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
@@ -239,14 +242,17 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "Dw7Cxas8W7O2usHMHok95elKDRU": {
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "oLciSn5b6-cqcJjzgMMwCw1moD8": {
+            "header": "Apply for a vehicle operator licence",
             "link_text": "Apply for a vehicle operator licence",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "LUIZbIuJ_xVZxwhkNAApcO4O_6o": {
+            "header": "Apply to become a registered social worker in England",
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
@@ -275,18 +281,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Apply for a vehicle operator licence",
             "link_text": "Apply for a vehicle operator licence",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Apply to become a registered social worker in England",
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Sign your mortgage deed",
             "link_text": "Sign your mortgage deed",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -311,18 +321,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Apply for a vehicle operator licence",
             "link_text": "Apply for a vehicle operator licence",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Apply to become a registered social worker in England",
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Sign your mortgage deed",
             "link_text": "Sign your mortgage deed",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -347,18 +361,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+             "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header":"Apply for a vehicle operator licence",
             "link_text": "Apply for a vehicle operator licence",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Apply to become a registered social worker in England",
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Sign your mortgage deed",
             "link_text": "Sign your mortgage deed",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -383,18 +401,22 @@
             "link_href": "https://subject-matter-specialists.ofqual.gov.uk/"
           },
           "dbs": {
+            "header": "Request a basic DBS check",
             "link_text": "Request a basic DBS check",
             "link_href": "https://www.gov.uk/request-copy-criminal-record"
           },
           "vehicleOperatorLicense": {
+            "header": "Apply for a vehicle operator licence",
             "link_text": "Apply for a vehicle operator licence",
             "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
           },
           "socialWorkEngland": {
+            "header": "Apply to become a registered social worker in England",
             "link_text": "Apply to become a registered social worker in England",
             "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
           },
           "mortgageDeed": {
+            "header": "Sign your mortgage deed",
             "link_text": "Sign your mortgage deed",
             "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
           }
@@ -553,9 +575,10 @@
       "title": "Are you sure you want to delete your GOV.UK One Login?",
       "header": "Are you sure you want to delete your GOV.UK One Login?",
       "paragraph1": "This will permanently delete the sign in details for your GOV.UK One Login.",
-      "paragraph2": "This means you’ll no longer be able to access the services you use with your GOV.UK One Login.",
-      "paragraph3": "If you have <a class=\"govuk-link\" href=\"[emailManagementLink]\">GOV.UK email subscriptions</a>, these will also be deleted.",
-      "paragraph4": "It will not delete the personal information held by services you’ve used with your GOV.UK One Login.",
+      "paragraph2": "You will no longer be able to sign in to use:",
+      "paragraph3": "This will also delete your GOV.UK email subscriptions.",
+      "paragraph4a": "It will not delete the personal information held by services you’ve used with your GOV.UK One Login.",
+      "paragraph4b": "It will not delete the personal information held by services you’ve used.",
       "paragraph5": "If you need a GOV.UK One Login in the future, you’ll have to create a new one.",
       "details": "Deleting your GOV.UK One Login will not affect any other government accounts you may have, such as Government Gateway or Universal Credit.",
       "deleteAccount": "Delete your GOV.UK One Login",

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -21,7 +21,7 @@ const serviceStoreDynamoDBRequest = (
 const unmarshallDynamoData = (dynamoDBResponse: DynamoDB.Types.AttributeMap) =>
   DynamoDB.Converter.unmarshall(dynamoDBResponse);
 
-export const getServices = async (subjectId: string): Promise<Service[]> => {
+const getServices = async (subjectId: string): Promise<Service[]> => {
   const logger = pino();
   try {
     const response = await dynamoDBService().getItem(
@@ -55,6 +55,22 @@ export const presentYourServices = async (
       accountsList: [],
       servicesList: [],
     };
+  }
+};
+
+export const getAllowedListServices = async (
+  subjectId: string
+): Promise<Service[]> => {
+  const userServices = await getServices(subjectId);
+  if (userServices) {
+    return userServices.filter((service) => {
+      return (
+        getAllowedAccountListClientIDs.includes(service.client_id) ||
+        getAllowedServiceListClientIDs.includes(service.client_id)
+      );
+    });
+  } else {
+    return [];
   }
 };
 

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -21,7 +21,7 @@ const serviceStoreDynamoDBRequest = (
 const unmarshallDynamoData = (dynamoDBResponse: DynamoDB.Types.AttributeMap) =>
   DynamoDB.Converter.unmarshall(dynamoDBResponse);
 
-const getServiceStoreItem = async (subjectId: string): Promise<Service[]> => {
+export const getServices = async (subjectId: string): Promise<Service[]> => {
   const logger = pino();
   try {
     const response = await dynamoDBService().getItem(
@@ -37,7 +37,7 @@ const getServiceStoreItem = async (subjectId: string): Promise<Service[]> => {
 export const presentYourServices = async (
   subjectId: string
 ): Promise<YourServices> => {
-  const userServices = await getServiceStoreItem(subjectId);
+  const userServices = await getServices(subjectId);
   if (userServices) {
     const userServicesWithPresentableDates = userServices.map((service) =>
       formatService(service)
@@ -66,4 +66,18 @@ export const formatService = (service: Service): Service => {
     last_accessed: service.last_accessed,
     last_accessed_readable_format: readable_format_date,
   };
+};
+
+export const containsGovUkPublishingService = (
+  serviceList: Service[]
+): boolean => {
+  const govUkPublishingClientIds: string[] = [
+    "LcueBVCnGZw-YFdTZ4S07XbQx7I",
+    "CEr97IZfEPQFgBxq8QNcM8LFxw4",
+    "gov-uk",
+  ];
+
+  return serviceList.some((service) => {
+    return govUkPublishingClientIds.includes(service.client_id);
+  });
 };

--- a/test/unit/utils/yourServices.test.ts
+++ b/test/unit/utils/yourServices.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { formatService } from "../../../src/utils/yourServices"
+import { formatService, containsGovUkPublishingService } from "../../../src/utils/yourServices"
 import type { Service } from "../../../src/utils/types";
 
 describe("YourService Util", () => {
@@ -21,6 +21,33 @@ describe("YourService Util", () => {
             expect(formattedService.last_accessed_readable_format).equal("10 January 2023");
           });
     
+    })
+
+    describe("does GovUK Publishing service exist in array", async () => {
+
+        it("return false if array does not contain govUK publishing service", () => {
+            const serviceList: Service[] = [
+                {
+                  client_id: "client_id",
+                  count_successful_logins: 1,
+                  last_accessed: 14567776,
+                  last_accessed_readable_format: "last_accessed_readable_format",
+                },
+              ];
+            expect(containsGovUkPublishingService(serviceList)).equal(false);
+        })
+
+        it("return true if array contains govUK publishing service", () => {
+            const serviceList: Service[] = [
+                {
+                  client_id: "gov-uk",
+                  count_successful_logins: 1,
+                  last_accessed: 14567776,
+                  last_accessed_readable_format: "last_accessed_readable_format",
+                },
+              ];
+            expect(containsGovUkPublishingService(serviceList)).equal(true);
+        })
     })
 })
  

--- a/test/unit/utils/yourServices.test.ts
+++ b/test/unit/utils/yourServices.test.ts
@@ -1,53 +1,55 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { formatService, containsGovUkPublishingService } from "../../../src/utils/yourServices"
+import {
+  formatService,
+  containsGovUkPublishingService,
+} from "../../../src/utils/yourServices";
 import type { Service } from "../../../src/utils/types";
 
 describe("YourService Util", () => {
-    describe("format service information to diplay", () => {
-        it("It takes a date epoch in seconds and returns a pretty formatted date", async () => {
-            const dateEpochInSeconds = 1673358736;
-            const serviceFromDb: Service = {
-                client_id : "a_client_id",
-                count_successful_logins : 1,
-                last_accessed : dateEpochInSeconds,
-                last_accessed_readable_format : undefined
-            }
-    
-            const formattedService: Service = formatService(serviceFromDb);
-    
-            expect(formattedService.client_id).equal("a_client_id");
-            expect(formattedService.count_successful_logins).equal(1);
-            expect(formattedService.last_accessed_readable_format).equal("10 January 2023");
-          });
-    
-    })
+  describe("format service information to diplay", () => {
+    it("It takes a date epoch in seconds and returns a pretty formatted date", async () => {
+      const dateEpochInSeconds = 1673358736;
+      const serviceFromDb: Service = {
+        client_id: "a_client_id",
+        count_successful_logins: 1,
+        last_accessed: dateEpochInSeconds,
+        last_accessed_readable_format: undefined,
+      };
 
-    describe("does GovUK Publishing service exist in array", async () => {
+      const formattedService: Service = formatService(serviceFromDb);
 
-        it("return false if array does not contain govUK publishing service", () => {
-            const serviceList: Service[] = [
-                {
-                  client_id: "client_id",
-                  count_successful_logins: 1,
-                  last_accessed: 14567776,
-                  last_accessed_readable_format: "last_accessed_readable_format",
-                },
-              ];
-            expect(containsGovUkPublishingService(serviceList)).equal(false);
-        })
+      expect(formattedService.client_id).equal("a_client_id");
+      expect(formattedService.count_successful_logins).equal(1);
+      expect(formattedService.last_accessed_readable_format).equal(
+        "10 January 2023"
+      );
+    });
+  });
 
-        it("return true if array contains govUK publishing service", () => {
-            const serviceList: Service[] = [
-                {
-                  client_id: "gov-uk",
-                  count_successful_logins: 1,
-                  last_accessed: 14567776,
-                  last_accessed_readable_format: "last_accessed_readable_format",
-                },
-              ];
-            expect(containsGovUkPublishingService(serviceList)).equal(true);
-        })
-    })
-})
- 
+  describe("does GovUK Publishing service exist in array", async () => {
+    it("return false if array does not contain govUK publishing service", () => {
+      const serviceList: Service[] = [
+        {
+          client_id: "client_id",
+          count_successful_logins: 1,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
+      ];
+      expect(containsGovUkPublishingService(serviceList)).equal(false);
+    });
+
+    it("return true if array contains govUK publishing service", () => {
+      const serviceList: Service[] = [
+        {
+          client_id: "gov-uk",
+          count_successful_logins: 1,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
+      ];
+      expect(containsGovUkPublishingService(serviceList)).equal(true);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,14 +4,14 @@
 
 "@aws-crypto/ie11-detection@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz#640ae66b4ec3395cee6a8e94ebcd9f80c24cd688"
+  resolved "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz"
   integrity sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==
   dependencies:
     tslib "^1.11.1"
 
 "@aws-crypto/sha256-browser@3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz#05f160138ab893f1c6ba5be57cfd108f05827766"
+  resolved "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz"
   integrity sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==
   dependencies:
     "@aws-crypto/ie11-detection" "^3.0.0"
@@ -25,7 +25,7 @@
 
 "@aws-crypto/sha256-js@3.0.0", "@aws-crypto/sha256-js@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz#f06b84d550d25521e60d2a0e2a90139341e007c2"
+  resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz"
   integrity sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==
   dependencies:
     "@aws-crypto/util" "^3.0.0"
@@ -34,571 +34,567 @@
 
 "@aws-crypto/supports-web-crypto@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz#5d1bf825afa8072af2717c3e455f35cda0103ec2"
+  resolved "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz"
   integrity sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==
   dependencies:
     tslib "^1.11.1"
 
 "@aws-crypto/util@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-3.0.0.tgz#1c7ca90c29293f0883468ad48117937f0fe5bfb0"
+  resolved "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz"
   integrity sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==
   dependencies:
     "@aws-sdk/types" "^3.222.0"
     "@aws-sdk/util-utf8-browser" "^3.0.0"
     tslib "^1.11.1"
 
-"@aws-sdk/abort-controller@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.254.0.tgz#62dfcbb2e58831b3fb26833227806ee06698f3f6"
-  integrity sha512-ZBJFCCU7mIXGLk5GFXrSReyUR/kOBju0kzd7nVAAQQlfkmHZEuFhKFFMXkfJZG0SC0ezCbmR/EzIqJ2mTI+pRA==
+"@aws-sdk/abort-controller@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.267.0.tgz"
+  integrity sha512-5R7OSnHFV/f+qQpMf1RuSQoVdXroK94Vl6naWjMOAhMyofHykVhEok9hmFPac86AVx8rVX/vuA7u9GKI6/EE7g==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/client-dynamodb@^3.245.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.256.0.tgz#41f0234369b95fd944fa80ed918948281ae0be9b"
-  integrity sha512-uDdnWpaaGsvsH/Fe56BbZpDUpmteH0DtEaroL9rnR33SwAnC8Rcu3KG7s2GLAR6JiyobELV+RLlTUKiYODAUDA==
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.267.0.tgz"
+  integrity sha512-TWlRGYbdCJtU1fiB6Zrv7C5zyeMGtn4Tt4X9BUSasiNylmY10DMA/mIve0r8dHg/tU8d89ljeK/xtqXlZ85r2g==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/client-sts" "3.256.0"
-    "@aws-sdk/config-resolver" "3.254.0"
-    "@aws-sdk/credential-provider-node" "3.256.0"
-    "@aws-sdk/fetch-http-handler" "3.254.0"
-    "@aws-sdk/hash-node" "3.254.0"
-    "@aws-sdk/invalid-dependency" "3.254.0"
-    "@aws-sdk/middleware-content-length" "3.254.0"
-    "@aws-sdk/middleware-endpoint" "3.254.0"
-    "@aws-sdk/middleware-endpoint-discovery" "3.254.0"
-    "@aws-sdk/middleware-host-header" "3.254.0"
-    "@aws-sdk/middleware-logger" "3.254.0"
-    "@aws-sdk/middleware-recursion-detection" "3.254.0"
-    "@aws-sdk/middleware-retry" "3.254.0"
-    "@aws-sdk/middleware-serde" "3.254.0"
-    "@aws-sdk/middleware-signing" "3.254.0"
-    "@aws-sdk/middleware-stack" "3.254.0"
-    "@aws-sdk/middleware-user-agent" "3.254.0"
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/node-http-handler" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/smithy-client" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/url-parser" "3.254.0"
+    "@aws-sdk/client-sts" "3.267.0"
+    "@aws-sdk/config-resolver" "3.267.0"
+    "@aws-sdk/credential-provider-node" "3.267.0"
+    "@aws-sdk/fetch-http-handler" "3.267.0"
+    "@aws-sdk/hash-node" "3.267.0"
+    "@aws-sdk/invalid-dependency" "3.267.0"
+    "@aws-sdk/middleware-content-length" "3.267.0"
+    "@aws-sdk/middleware-endpoint" "3.267.0"
+    "@aws-sdk/middleware-endpoint-discovery" "3.267.0"
+    "@aws-sdk/middleware-host-header" "3.267.0"
+    "@aws-sdk/middleware-logger" "3.267.0"
+    "@aws-sdk/middleware-recursion-detection" "3.267.0"
+    "@aws-sdk/middleware-retry" "3.267.0"
+    "@aws-sdk/middleware-serde" "3.267.0"
+    "@aws-sdk/middleware-signing" "3.267.0"
+    "@aws-sdk/middleware-stack" "3.267.0"
+    "@aws-sdk/middleware-user-agent" "3.267.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/node-http-handler" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/smithy-client" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/url-parser" "3.267.0"
     "@aws-sdk/util-base64" "3.208.0"
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.254.0"
-    "@aws-sdk/util-defaults-mode-node" "3.254.0"
-    "@aws-sdk/util-endpoints" "3.254.0"
-    "@aws-sdk/util-retry" "3.254.0"
-    "@aws-sdk/util-user-agent-browser" "3.254.0"
-    "@aws-sdk/util-user-agent-node" "3.254.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.208.0"
-    "@aws-sdk/util-waiter" "3.254.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.267.0"
+    "@aws-sdk/util-defaults-mode-node" "3.267.0"
+    "@aws-sdk/util-endpoints" "3.267.0"
+    "@aws-sdk/util-retry" "3.267.0"
+    "@aws-sdk/util-user-agent-browser" "3.267.0"
+    "@aws-sdk/util-user-agent-node" "3.267.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    "@aws-sdk/util-waiter" "3.267.0"
     tslib "^2.3.1"
     uuid "^8.3.2"
 
-"@aws-sdk/client-sso-oidc@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.256.0.tgz#c71f29df3fb1cd152208575bd7f3ee102211bebf"
-  integrity sha512-HR57pMdL5zGpxHnKYx1HjgnbVYlhTDZwyBS7k9JfiEDwPnGH8y169aNgVs+iaX0rIRlv6AyVstjqjZXGxODS4w==
+"@aws-sdk/client-sso-oidc@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.267.0.tgz"
+  integrity sha512-Jdq0v0mJSJbG/CKLfHC1L0cjCot48Y6lLMQV1lfkYE65xD0ZSs8Gl7P/T391ZH7cLO6ifVoPdsYnwzhi1ZPXSQ==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.254.0"
-    "@aws-sdk/fetch-http-handler" "3.254.0"
-    "@aws-sdk/hash-node" "3.254.0"
-    "@aws-sdk/invalid-dependency" "3.254.0"
-    "@aws-sdk/middleware-content-length" "3.254.0"
-    "@aws-sdk/middleware-endpoint" "3.254.0"
-    "@aws-sdk/middleware-host-header" "3.254.0"
-    "@aws-sdk/middleware-logger" "3.254.0"
-    "@aws-sdk/middleware-recursion-detection" "3.254.0"
-    "@aws-sdk/middleware-retry" "3.254.0"
-    "@aws-sdk/middleware-serde" "3.254.0"
-    "@aws-sdk/middleware-stack" "3.254.0"
-    "@aws-sdk/middleware-user-agent" "3.254.0"
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/node-http-handler" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/smithy-client" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/url-parser" "3.254.0"
+    "@aws-sdk/config-resolver" "3.267.0"
+    "@aws-sdk/fetch-http-handler" "3.267.0"
+    "@aws-sdk/hash-node" "3.267.0"
+    "@aws-sdk/invalid-dependency" "3.267.0"
+    "@aws-sdk/middleware-content-length" "3.267.0"
+    "@aws-sdk/middleware-endpoint" "3.267.0"
+    "@aws-sdk/middleware-host-header" "3.267.0"
+    "@aws-sdk/middleware-logger" "3.267.0"
+    "@aws-sdk/middleware-recursion-detection" "3.267.0"
+    "@aws-sdk/middleware-retry" "3.267.0"
+    "@aws-sdk/middleware-serde" "3.267.0"
+    "@aws-sdk/middleware-stack" "3.267.0"
+    "@aws-sdk/middleware-user-agent" "3.267.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/node-http-handler" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/smithy-client" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/url-parser" "3.267.0"
     "@aws-sdk/util-base64" "3.208.0"
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.254.0"
-    "@aws-sdk/util-defaults-mode-node" "3.254.0"
-    "@aws-sdk/util-endpoints" "3.254.0"
-    "@aws-sdk/util-retry" "3.254.0"
-    "@aws-sdk/util-user-agent-browser" "3.254.0"
-    "@aws-sdk/util-user-agent-node" "3.254.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.267.0"
+    "@aws-sdk/util-defaults-mode-node" "3.267.0"
+    "@aws-sdk/util-endpoints" "3.267.0"
+    "@aws-sdk/util-retry" "3.267.0"
+    "@aws-sdk/util-user-agent-browser" "3.267.0"
+    "@aws-sdk/util-user-agent-node" "3.267.0"
+    "@aws-sdk/util-utf8" "3.254.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.256.0.tgz#8dfd3e69e0eae9937f1b7cee0d95dca7995ad867"
-  integrity sha512-e+BNJ95IqUU1nmmX51T3ehy8yqHDN8J4DH6FReK1vrFIMEra/wERGJBcm+pdojyllQ20FQRBvGtOzN/WspH74w==
+"@aws-sdk/client-sso@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.267.0.tgz"
+  integrity sha512-/475/mT0gYhimpCdK4iZW+eX0DT6mkTgVk5P9ARpQGzEblFM6i2pE7GQnlGeLyHVOtA0cNAyGrWUuj2pyigUaA==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.254.0"
-    "@aws-sdk/fetch-http-handler" "3.254.0"
-    "@aws-sdk/hash-node" "3.254.0"
-    "@aws-sdk/invalid-dependency" "3.254.0"
-    "@aws-sdk/middleware-content-length" "3.254.0"
-    "@aws-sdk/middleware-endpoint" "3.254.0"
-    "@aws-sdk/middleware-host-header" "3.254.0"
-    "@aws-sdk/middleware-logger" "3.254.0"
-    "@aws-sdk/middleware-recursion-detection" "3.254.0"
-    "@aws-sdk/middleware-retry" "3.254.0"
-    "@aws-sdk/middleware-serde" "3.254.0"
-    "@aws-sdk/middleware-stack" "3.254.0"
-    "@aws-sdk/middleware-user-agent" "3.254.0"
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/node-http-handler" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/smithy-client" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/url-parser" "3.254.0"
+    "@aws-sdk/config-resolver" "3.267.0"
+    "@aws-sdk/fetch-http-handler" "3.267.0"
+    "@aws-sdk/hash-node" "3.267.0"
+    "@aws-sdk/invalid-dependency" "3.267.0"
+    "@aws-sdk/middleware-content-length" "3.267.0"
+    "@aws-sdk/middleware-endpoint" "3.267.0"
+    "@aws-sdk/middleware-host-header" "3.267.0"
+    "@aws-sdk/middleware-logger" "3.267.0"
+    "@aws-sdk/middleware-recursion-detection" "3.267.0"
+    "@aws-sdk/middleware-retry" "3.267.0"
+    "@aws-sdk/middleware-serde" "3.267.0"
+    "@aws-sdk/middleware-stack" "3.267.0"
+    "@aws-sdk/middleware-user-agent" "3.267.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/node-http-handler" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/smithy-client" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/url-parser" "3.267.0"
     "@aws-sdk/util-base64" "3.208.0"
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.254.0"
-    "@aws-sdk/util-defaults-mode-node" "3.254.0"
-    "@aws-sdk/util-endpoints" "3.254.0"
-    "@aws-sdk/util-retry" "3.254.0"
-    "@aws-sdk/util-user-agent-browser" "3.254.0"
-    "@aws-sdk/util-user-agent-node" "3.254.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.267.0"
+    "@aws-sdk/util-defaults-mode-node" "3.267.0"
+    "@aws-sdk/util-endpoints" "3.267.0"
+    "@aws-sdk/util-retry" "3.267.0"
+    "@aws-sdk/util-user-agent-browser" "3.267.0"
+    "@aws-sdk/util-user-agent-node" "3.267.0"
+    "@aws-sdk/util-utf8" "3.254.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sts@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.256.0.tgz#c71610393736b63c58c4cdc1caec302508fe8fc8"
-  integrity sha512-6jqaM7/Lw41kuEz8CqLU+fOLDF8C6W+jG30zBQrAC+iYSTB0w9uGOzVxsan1Nesg1FpoBqnWcF7xWi6Ox+OeDg==
+"@aws-sdk/client-sts@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.267.0.tgz"
+  integrity sha512-bJ+SwJZAP3DuDUgToDV89HsB80IhSfB1rhzLG9csqs6h7uMLO8H1/fymElYKT4VMMAA+rpWJ3pznyGiCK7w28A==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.254.0"
-    "@aws-sdk/credential-provider-node" "3.256.0"
-    "@aws-sdk/fetch-http-handler" "3.254.0"
-    "@aws-sdk/hash-node" "3.254.0"
-    "@aws-sdk/invalid-dependency" "3.254.0"
-    "@aws-sdk/middleware-content-length" "3.254.0"
-    "@aws-sdk/middleware-endpoint" "3.254.0"
-    "@aws-sdk/middleware-host-header" "3.254.0"
-    "@aws-sdk/middleware-logger" "3.254.0"
-    "@aws-sdk/middleware-recursion-detection" "3.254.0"
-    "@aws-sdk/middleware-retry" "3.254.0"
-    "@aws-sdk/middleware-sdk-sts" "3.254.0"
-    "@aws-sdk/middleware-serde" "3.254.0"
-    "@aws-sdk/middleware-signing" "3.254.0"
-    "@aws-sdk/middleware-stack" "3.254.0"
-    "@aws-sdk/middleware-user-agent" "3.254.0"
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/node-http-handler" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/smithy-client" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/url-parser" "3.254.0"
+    "@aws-sdk/config-resolver" "3.267.0"
+    "@aws-sdk/credential-provider-node" "3.267.0"
+    "@aws-sdk/fetch-http-handler" "3.267.0"
+    "@aws-sdk/hash-node" "3.267.0"
+    "@aws-sdk/invalid-dependency" "3.267.0"
+    "@aws-sdk/middleware-content-length" "3.267.0"
+    "@aws-sdk/middleware-endpoint" "3.267.0"
+    "@aws-sdk/middleware-host-header" "3.267.0"
+    "@aws-sdk/middleware-logger" "3.267.0"
+    "@aws-sdk/middleware-recursion-detection" "3.267.0"
+    "@aws-sdk/middleware-retry" "3.267.0"
+    "@aws-sdk/middleware-sdk-sts" "3.267.0"
+    "@aws-sdk/middleware-serde" "3.267.0"
+    "@aws-sdk/middleware-signing" "3.267.0"
+    "@aws-sdk/middleware-stack" "3.267.0"
+    "@aws-sdk/middleware-user-agent" "3.267.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/node-http-handler" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/smithy-client" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/url-parser" "3.267.0"
     "@aws-sdk/util-base64" "3.208.0"
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.254.0"
-    "@aws-sdk/util-defaults-mode-node" "3.254.0"
-    "@aws-sdk/util-endpoints" "3.254.0"
-    "@aws-sdk/util-retry" "3.254.0"
-    "@aws-sdk/util-user-agent-browser" "3.254.0"
-    "@aws-sdk/util-user-agent-node" "3.254.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.267.0"
+    "@aws-sdk/util-defaults-mode-node" "3.267.0"
+    "@aws-sdk/util-endpoints" "3.267.0"
+    "@aws-sdk/util-retry" "3.267.0"
+    "@aws-sdk/util-user-agent-browser" "3.267.0"
+    "@aws-sdk/util-user-agent-node" "3.267.0"
+    "@aws-sdk/util-utf8" "3.254.0"
     fast-xml-parser "4.0.11"
     tslib "^2.3.1"
 
-"@aws-sdk/config-resolver@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.254.0.tgz#82504a1886f90fc1374b77d65187058a04430204"
-  integrity sha512-+t5mi/SrZdAbSgg/5b/q3zVZsNQSyty2XX+znaRvBdANtIWIBdFLEMQp/L5NA+PSiW6VUXu9eXcsj0kJlAhTgQ==
+"@aws-sdk/config-resolver@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.267.0.tgz"
+  integrity sha512-UMvJY548xOkamU9ZuZk336VX9r3035CAbttagiPJ/FXy9S8jcQ7N722PAovtxs69nNBQf56cmWsnOHphLCGG9w==
   dependencies:
-    "@aws-sdk/signature-v4" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/signature-v4" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     "@aws-sdk/util-config-provider" "3.208.0"
-    "@aws-sdk/util-middleware" "3.254.0"
+    "@aws-sdk/util-middleware" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-env@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.254.0.tgz#8ad17baa3108ed25509db1b994a3a51cb17ff427"
-  integrity sha512-2CDwb7L1XGTY7Y8N3EsE1xqas0zNvrs4aOEv5XZNrKqE+9bvs8CiUwV4SB6VwSD+EPcOSm3QYEURUmj5EyLEZQ==
+"@aws-sdk/credential-provider-env@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.267.0.tgz"
+  integrity sha512-oiem2UtaFe4CQHscUCImJjPhYWd4iF8fqXhlq6BqHs1wsO6A0vnIUGh+Srut/2q7Xeegl/SRU34HK0hh8JCbxg==
   dependencies:
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-imds@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.254.0.tgz#876282edc865747b574a537d59c4cf47cf4b37d3"
-  integrity sha512-sM3N7FLz+svRGjTgwAybKBmu5tVfCJmd5HPEfKR0jfBWB1uq0u0J+65JiO/wfqn/ix+3ZyFfacSJDFjnSPu/KA==
+"@aws-sdk/credential-provider-imds@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.267.0.tgz"
+  integrity sha512-Afd5+LdJ9QyeI5L4iyVmI4MLV+0JBtRLmRy0LdinwJaP0DyKyv9+uaIaorKfWihQpe8hwjEfQWTlTz2A3JMJtw==
   dependencies:
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/url-parser" "3.254.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/url-parser" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-ini@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.256.0.tgz#6fc7905cedbdb33df40bdbfc7bbfe0a0a5200e4a"
-  integrity sha512-tZacj/dVnu2GuNSVpYaO6JHrpaWqz9wvOkf/lYxh1Ga993uhF6SWLfENM29gF/EjvV0Nn0beHfyz5Em7dFbw8g==
+"@aws-sdk/credential-provider-ini@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.267.0.tgz"
+  integrity sha512-pHHlqZqZXA4cTssTyRmbYtrjxS2BEy2KFYHEEHNUrd82pUHnj70n+lrpVnT5pRhPPDacpNzxq0KZGeNgmETpbw==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.254.0"
-    "@aws-sdk/credential-provider-imds" "3.254.0"
-    "@aws-sdk/credential-provider-process" "3.254.0"
-    "@aws-sdk/credential-provider-sso" "3.256.0"
-    "@aws-sdk/credential-provider-web-identity" "3.254.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/shared-ini-file-loader" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/credential-provider-env" "3.267.0"
+    "@aws-sdk/credential-provider-imds" "3.267.0"
+    "@aws-sdk/credential-provider-process" "3.267.0"
+    "@aws-sdk/credential-provider-sso" "3.267.0"
+    "@aws-sdk/credential-provider-web-identity" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/shared-ini-file-loader" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-node@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.256.0.tgz#ab9954548416130152d8496a3b6494d78dc555e6"
-  integrity sha512-A/C8379FjeDYzfG+KQOyMgUnH/Fr7MFoeyhH9pECp5KWzts6H4IIQ1XUN7H/dmeqGfFxU7E7Hya2k1BX4qrKwQ==
+"@aws-sdk/credential-provider-node@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.267.0.tgz"
+  integrity sha512-uo8VyZ/L8HBXskYZC65bR1ZUJ5mBn8JarrGHt6vMG2A+uM7AuryTsKn2wdhPfuCUGKuQLXmix5K4VW/wzq11kQ==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.254.0"
-    "@aws-sdk/credential-provider-imds" "3.254.0"
-    "@aws-sdk/credential-provider-ini" "3.256.0"
-    "@aws-sdk/credential-provider-process" "3.254.0"
-    "@aws-sdk/credential-provider-sso" "3.256.0"
-    "@aws-sdk/credential-provider-web-identity" "3.254.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/shared-ini-file-loader" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/credential-provider-env" "3.267.0"
+    "@aws-sdk/credential-provider-imds" "3.267.0"
+    "@aws-sdk/credential-provider-ini" "3.267.0"
+    "@aws-sdk/credential-provider-process" "3.267.0"
+    "@aws-sdk/credential-provider-sso" "3.267.0"
+    "@aws-sdk/credential-provider-web-identity" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/shared-ini-file-loader" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-process@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.254.0.tgz#31e6c0c709d47b9a87397698ab942a820dfa5f38"
-  integrity sha512-vNm1AHMu5Lg1kOMk4ucWgaNO4zNAD7aeRssdBMnC7WqRT2xB8CUEWi+zJGNjbxzEeTLXQZuMa1VeRT3nPjYrzg==
+"@aws-sdk/credential-provider-process@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.267.0.tgz"
+  integrity sha512-pd1OOB1Mm+QdPv3sPfO+1G8HBaPAAYXxjLcOK5z/myBeZAsLR12Xcaft4RR1XWwXXKEQqq42cbAINWQdyVykqQ==
   dependencies:
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/shared-ini-file-loader" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/shared-ini-file-loader" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-sso@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.256.0.tgz#5aa418c87ec6018ed768fe02bab42a1b5d6a3420"
-  integrity sha512-5WV62oxuM1LM9udmouxkGbnkN7sKqF4drYBBt2DetQzq4NStaOtZgcY0fxcX/HFv0Q2wjSWCBtDQ31Jo1CJRew==
+"@aws-sdk/credential-provider-sso@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.267.0.tgz"
+  integrity sha512-JqwxelzeRhVdloNi+VUUXhJdziTtNrrwMuhds9wj4KPfl1S2EIzkRxHSjwDz1wtSyuIPOOo6pPJiaVbwvLpkVg==
   dependencies:
-    "@aws-sdk/client-sso" "3.256.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/shared-ini-file-loader" "3.254.0"
-    "@aws-sdk/token-providers" "3.256.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/client-sso" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/shared-ini-file-loader" "3.267.0"
+    "@aws-sdk/token-providers" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-web-identity@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.254.0.tgz#17ef2052180c929f1f3807704522bd1931b7c2ab"
-  integrity sha512-R/5qjAoCHEe7xmY5j0vges4xKpFpTgrwzdST822JVNWUobZmiDUqnn+1Xw4Qmomst625NOpgzsV4JuHsA4a8Ig==
+"@aws-sdk/credential-provider-web-identity@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.267.0.tgz"
+  integrity sha512-za5UsQmj3sYRhd4h5eStj3GCHHfAAjfx2x5FmgQ9ldOp+s0wHEqSL1g+OL9v6o8otf9JnWha+wfUYq3yVGfufQ==
   dependencies:
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/endpoint-cache@3.208.0":
   version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz#bd3083c3b85985fb04ec0ab760afc7b4132318c3"
+  resolved "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz"
   integrity sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==
   dependencies:
     mnemonist "0.38.3"
     tslib "^2.3.1"
 
-"@aws-sdk/fetch-http-handler@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.254.0.tgz#cdc646f48bbfe35ea87ebcc2b5b050e17bbda7a8"
-  integrity sha512-/bbtNHe5JHFdKnCVr3Zx55sqs4c0F+7f1CC5cvTgH3O46wgIRM/6/rvE0YieXmfm3ho/GOhxBUzy59A0haKQGg==
+"@aws-sdk/fetch-http-handler@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.267.0.tgz"
+  integrity sha512-u8v8OvWvLVfifmETCAj+DCTot900AsdO1b+N+O8nXiTm2v99rtEoNRJW+no/5vJKNqR+95OAz4NWjFep8nzseg==
   dependencies:
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/querystring-builder" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/querystring-builder" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     "@aws-sdk/util-base64" "3.208.0"
     tslib "^2.3.1"
 
-"@aws-sdk/hash-node@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.254.0.tgz#b69c9dba780ce86cf24effb3c8416eb16586a502"
-  integrity sha512-7FoB6BVbO+Z/NEOHeOAoUTyj8q+Pcdn4QpKvA4epRDrzMNcXy7MUNzzt148nkDssES09rgsN+KM8Zo2qgRYngg==
+"@aws-sdk/hash-node@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.267.0.tgz"
+  integrity sha512-N3xeChdJg4V4jh2vrRN521EMJYxjUOo/LpvpisFyQHE/p31AfcOLb05upYFoYLvyeder9RHBIyNsvvnMYYoCsA==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     "@aws-sdk/util-buffer-from" "3.208.0"
     "@aws-sdk/util-utf8" "3.254.0"
     tslib "^2.3.1"
 
-"@aws-sdk/invalid-dependency@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.254.0.tgz#a2df8be8257a2edda41301600a73520f7539540d"
-  integrity sha512-ueV0tXyGndCTZXnEv+AMeTfu+IqV2QzmGMXcakiwxDjg48H9X/bLnj+C96Sexond8jD8K0ub9HWhkBrvvAXlPA==
+"@aws-sdk/invalid-dependency@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.267.0.tgz"
+  integrity sha512-I95IR/eDLC54+9qrL6uh64nhpLVHwxxbBhhEUZKDACp86eXulO8T/DOwUX31ps4+2lI7tbEhQT7f9WDOO3fN8Q==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/is-array-buffer@3.201.0":
   version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz#06e557adc284fac2f26071c2944ae01f61b95854"
+  resolved "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz"
   integrity sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-content-length@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.254.0.tgz#ecf39dac8b056fb6c32860d65080b9b71d02a72c"
-  integrity sha512-IT7nDZA6WsaZSNp9M79xfkk/us4kGV4SIZ2R9gHT9MFqdmpmbr3EGhFLKXUHcAZfCcOdw+JNV/wHJiiN1JD/hg==
+"@aws-sdk/middleware-content-length@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.267.0.tgz"
+  integrity sha512-b6MBIK12iwcATKnWIhsh50xWVMmZOXZFIo9D4io6D+JM6j/U+GZrSWqxhHzb3SjavuwVgA2hwq4mUCh2WJPJKA==
   dependencies:
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-endpoint-discovery@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.254.0.tgz#9634200fa2cd82833c54b62bdb97de3e0fd3b52b"
-  integrity sha512-QFFo7X7yTmo42XLajQ8J3ozDB5aPZScJwXra7iJOhFAl3JbQOGnVIleNZLnLAPMxJ6efZYu9YxFSgJIf96yDkg==
+"@aws-sdk/middleware-endpoint-discovery@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.267.0.tgz"
+  integrity sha512-R7hfV/aRRuCtdNH/cbnKir3idEvLVSmemW/ndYL4WONTOqWKWEnVq55ortgg69S/b2+hdpIQnAkLhIlq5KBDOg==
   dependencies:
-    "@aws-sdk/config-resolver" "3.254.0"
+    "@aws-sdk/config-resolver" "3.267.0"
     "@aws-sdk/endpoint-cache" "3.208.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-endpoint@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.254.0.tgz#9af598ce63a87eed13f84d1a9bfff4da9dd25790"
-  integrity sha512-9fkDtSJdhEr91tWp4zLyKhHDGVyvUA0gDK+6wGYyorKCae2qX2TL+Fl6vsqY4PxrdTpXRBJDlJnEly9i48YKxg==
+"@aws-sdk/middleware-endpoint@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.267.0.tgz"
+  integrity sha512-pGICM/qlQVfixtfKZt8zHq54KvLG2MmOAgNWj2MXB7oirPs/3rC9Kz9ITFXJgjlRFyfssgP/feKhs2yZkI8lhw==
   dependencies:
-    "@aws-sdk/middleware-serde" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/signature-v4" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/url-parser" "3.254.0"
+    "@aws-sdk/middleware-serde" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/signature-v4" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/url-parser" "3.267.0"
     "@aws-sdk/util-config-provider" "3.208.0"
-    "@aws-sdk/util-middleware" "3.254.0"
+    "@aws-sdk/util-middleware" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-host-header@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.254.0.tgz#6cdf432132e546f248f626dc6d955285abee6595"
-  integrity sha512-JG+OoyCMivnqTYiPZxRF+sgYEyQG68+PMl2843owvSxQQ25nH2Ih6DzLqH10c/uAN0PsiA8s/FfJBzhw9Xf0KA==
+"@aws-sdk/middleware-host-header@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.267.0.tgz"
+  integrity sha512-D8TfjMeuQXTsB7Ni8liMmNqb3wz+T6t/tYUHtsMo0j++94KAPPj1rhkkTAjR4Rc+IYGCS4YyyCuCXjGB6gkjnA==
   dependencies:
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-logger@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.254.0.tgz#d5ece30ef193da78c71c9abe38ae30b6511000c0"
-  integrity sha512-h3jEw58VUJkfqrwWMmp3Qc8293RFo4LMqxNAVsVwYEG6xb/RQ+JamsOx+t6aDsoOdKqhYngWwDGtgUZQ5wQQvg==
+"@aws-sdk/middleware-logger@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.267.0.tgz"
+  integrity sha512-wnLeZYWbgGCuNmRl0Pmky0cSXBWmMTaQBgq90WfwyM0V8wzcoeaovTWA5/qe8oJzusOgUMFoVia4Ew20k3lu8w==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-recursion-detection@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.254.0.tgz#605ab3ff47c8ac1fca2d092d570151d7afbe8ae8"
-  integrity sha512-/4tTvAXmIIMCs3giPIXN9aVJUGMoBMWw+9WS22u7nYNzwTe/k30DhS91uvwj7TLOOpFN0IBNXPCJ+T1OZn+ZXQ==
+"@aws-sdk/middleware-recursion-detection@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.267.0.tgz"
+  integrity sha512-NCBkTLxaW7XtfQoVBqQCaQZqec5XDtEylkw7g0tGjYDcl934fzu3ciH9MsJ34QFe9slYM6g4v+eC9f1w9K/19g==
   dependencies:
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-retry@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.254.0.tgz#0af8f8c06e42879cbc1f23e6d2166d61953c0f2d"
-  integrity sha512-nHgris8NmtLzsH5iUA8geW6RAT1VRymjlieKFmM3CAYt2h2X8AtAiL/Wod+Pj3+jjRGk9YeGzOOGbzODHiRxnA==
+"@aws-sdk/middleware-retry@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.267.0.tgz"
+  integrity sha512-MiiNtddZXVhtSAnJFyChwNxnhzMYmv6qWl8qgSjuIOw9SczkHPCoANTfUdRlzG6RfPYhgYtzMGqqnrficJ6mVg==
   dependencies:
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/service-error-classification" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/util-middleware" "3.254.0"
-    "@aws-sdk/util-retry" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/service-error-classification" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/util-middleware" "3.267.0"
+    "@aws-sdk/util-retry" "3.267.0"
     tslib "^2.3.1"
     uuid "^8.3.2"
 
-"@aws-sdk/middleware-sdk-sts@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.254.0.tgz#5382f65872fe9917ac817273ae6e1ffa6cbcdffa"
-  integrity sha512-Y074nmTp07thuOI6GePv8IKdL/OvkO1tn2l7QvnwQa3Sy/HyNai1V3MVtq4hRi1dgDjheKPVHPE+TnOmF3w5uA==
+"@aws-sdk/middleware-sdk-sts@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.267.0.tgz"
+  integrity sha512-JLDNNvV7Hr0CQrf1vSmflvPbfDFIx5lFf8tY7DZwYWEE920ZzbJTfUsTW9iZHJGeIe8dAQX1tmfYL68+++nvEQ==
   dependencies:
-    "@aws-sdk/middleware-signing" "3.254.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/signature-v4" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/middleware-signing" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/signature-v4" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-serde@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.254.0.tgz#57b6579d6d5b6dcd260c088bec8f4cacb6adf5f0"
-  integrity sha512-YuItb2nlKADTBItcn68eA8amX4quuR1+0GyFRkwssKS/iTjbIk+3gJ2s1zxkUhlyozH3U38Jvvqd+W9+gNpYIg==
+"@aws-sdk/middleware-serde@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.267.0.tgz"
+  integrity sha512-9qspxiZs+JShukzKMAameBSubfvtUOGZviu9GT5OfRekY2dBbwWcfchP2WvlwxZ/CcC+GwO1HcPqKDCMGsNoow==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-signing@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.254.0.tgz#d08cf8c163a90d76a5139c23eecfffb475b6494f"
-  integrity sha512-HMVGf+yANjlKCUMFZJU2PNzbI9hbCgL+IX/Y4DGuQW9cp7EgZOxQre1LBKpcCqqPVQ4toIdfNH/K8uM2fpO6dg==
+"@aws-sdk/middleware-signing@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.267.0.tgz"
+  integrity sha512-thkFEBiFW0M/73dIzl7hQmyAONb8zyD2ZYUFyGm7cIM60sRDUKejPHV6Izonll+HbBZgiBdwUi42uu8O+LfFGQ==
   dependencies:
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/signature-v4" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
-    "@aws-sdk/util-middleware" "3.254.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/signature-v4" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
+    "@aws-sdk/util-middleware" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-stack@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.254.0.tgz#1ec3b7ce4a9e62c630119cb3d4ec47df8cf2c185"
-  integrity sha512-yPWRnjeLC0lPAEQbiqbC3+hnqXZ+uCSoSevGndU5KWMMiXLxKZn7Y0B3kG8NAnNNuPid+wYFWWU9rKiBRvWR/w==
+"@aws-sdk/middleware-stack@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.267.0.tgz"
+  integrity sha512-52uH3JO3ceI15dgzt8gU7lpJf59qbRUQYJ7pAmTMiHtyEawZ39Puv6sGheY3fAffhqd/aQvup6wn18Q1fRIQUA==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-user-agent@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.254.0.tgz#b0b54aae78044db72605bfb3cda7099c840f600f"
-  integrity sha512-hp5UYRg3ysZXMFMv34nYexyom6Z3pdx+OmisJz4w3AMigT8y57Ps30Vg+1QYaGlQkI4vfvcmdZX2Q+kp+mb9gQ==
+"@aws-sdk/middleware-user-agent@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.267.0.tgz"
+  integrity sha512-eaReMnoB1Cx3OY8WDSiUMNDz/EkdAo4w/m3d5CizckKQNmB29gUrgyFs7g7sHTcShQAduZzlsfRPzc6NmKYaWQ==
   dependencies:
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/node-config-provider@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.254.0.tgz#0919e198e28144a85f97928ceccaf509db796a5b"
-  integrity sha512-3Bp3Gp2NOY9gab738xf07TysO5iB0Ib9qRNGDlxX8SX8fZDRnxrF2cn+Tjte42wrO54orwhSyuTaIlAqKeii8Q==
+"@aws-sdk/node-config-provider@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.267.0.tgz"
+  integrity sha512-wNX+Cu0x+kllng253j5dvmLm4opDRr7YehJ0rNGAV24X+UPJPluN9HrBFly+z4+bH16TpJEPKx7AayiWZGFE1w==
   dependencies:
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/shared-ini-file-loader" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/shared-ini-file-loader" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/node-http-handler@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.254.0.tgz#5007434b0ed387f110639cf74f7cbb6abebd6e68"
-  integrity sha512-DX2WJ3pub+3FF9GpoF5doERCn06MxS/UmmbKnIIokWQHjPZVomNh/1P3Cf9Jn9jeIPgh4UOg0uPD8cUm/cwHQw==
+"@aws-sdk/node-http-handler@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.267.0.tgz"
+  integrity sha512-wtt3O+e8JEKaLFtmQd74HSZj2TyiApPkwMJ3R50hyboVswt8RcdMWdFbzLnPVpT1AqskG3fMECSKbu8AC/xvBQ==
   dependencies:
-    "@aws-sdk/abort-controller" "3.254.0"
-    "@aws-sdk/protocol-http" "3.254.0"
-    "@aws-sdk/querystring-builder" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/abort-controller" "3.267.0"
+    "@aws-sdk/protocol-http" "3.267.0"
+    "@aws-sdk/querystring-builder" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/property-provider@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.254.0.tgz#4c815471e0aade6644b2923bb3c1a26c1e2cb1e8"
-  integrity sha512-BLZF/LDFjAgv2ZY0vhThU58k++Aw+SK7qNU7XT0D84q5iWlYRKptQEvSSvIkBSI/rZoppOFhK7W80I8kNNbh+Q==
+"@aws-sdk/property-provider@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.267.0.tgz"
+  integrity sha512-/BD1Zar9PCQSV8VZTAWOJmtojAeMIl16ljZX3Kix84r45qqNNxuPST2AhNVN+p97Js4x9kBFCHkdFOpW94wr4Q==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/protocol-http@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.254.0.tgz#b1ea17a599e50f30a3fc252de7aa4ced1f99acdd"
-  integrity sha512-4o/I/qhMUTp70njwWe3ttyRJSAKegnr8l3oVWAf1/q1ZHpcxbRRZEDvrkx4KSunFeXTTGHcff1oyLSRG/cKMsQ==
+"@aws-sdk/protocol-http@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.267.0.tgz"
+  integrity sha512-8HhOZXMCZ0nsJC/FoifX7YrTYGP91tCpSxIHkr7HxQcTdBMI7QakMtIIWK9Qjsy6tUI98aAdEo5PNCbzdpozmQ==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/querystring-builder@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.254.0.tgz#e542ca41e9b24828a92087d24e1f37aec1c3c4b3"
-  integrity sha512-Er+pOGTrPxelrzggibduO+eB1ClaU2BhjA8gd0nORS3kqktQggG3tKmRSIilegi9WOa3awCk6CnnuAf0pBrbUA==
+"@aws-sdk/querystring-builder@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.267.0.tgz"
+  integrity sha512-SKo8V3oPV1wZy4r4lccH7R2LT0PUK/WGaXkKR30wyrtDjJRWVJDYef9ysOpRP+adCTt3G5XO0SzyPQUW5dXYVA==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     "@aws-sdk/util-uri-escape" "3.201.0"
     tslib "^2.3.1"
 
-"@aws-sdk/querystring-parser@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.254.0.tgz#ebca5a4e78bb5ad4e2e6a44447083d09212cf450"
-  integrity sha512-WwRD99dwGo2aIrRjLHUAXaWCZ+3fj88IhIwciWTqrHBS3TQWXllOOQmYo7f+aMBB4Q1K6KdKITNi8L7aUuDv2g==
+"@aws-sdk/querystring-parser@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.267.0.tgz"
+  integrity sha512-Krq36GXqEfRfzJ9wOzkkzpbb4SWjgSYydTIgK6KtKapme0HPcB24kmmsjsUVuHzKuQMCHHDRWm+b47iBmHGpSQ==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/service-error-classification@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.254.0.tgz#1cf2a2e79fd73d48e751207e25527988dd6716d1"
-  integrity sha512-8GHqMJBBF9yoMBG/Nf9PusUSMFjG8ygps/cSJPlgcG2vbFn8BCdBZVc4ptXqICZUnBB/6lrxy8nCmNUaru48jg==
+"@aws-sdk/service-error-classification@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.267.0.tgz"
+  integrity sha512-fOWg7bcItmJqD/YQbGvN9o03ucoBzvWNTQEB81mLKMSKr1Cf/ms0f8oa94LlImgqjjfjvAqHh6rUBTpSmSEyaw==
 
-"@aws-sdk/shared-ini-file-loader@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.254.0.tgz#1d26b8d98541755dc6a4b8027110fea2b86b6257"
-  integrity sha512-UH4YTXuG+q004vA+jNrVhrD5XQCIAgpL/eriObJnQpKUVef1mkkEDHZs8+8+ZPsk4p/iBrIJ3lXNf7iDA/BFzw==
+"@aws-sdk/shared-ini-file-loader@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.267.0.tgz"
+  integrity sha512-Jz9R5hXKSk+aRoBKi4Bnf6T/FZUBYrIibbLnhiNxpQ1FY9mTggJR/rxuIdOE23LtfW+CRqqEYOtAtmC1oYE6tw==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/signature-v4@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.254.0.tgz#a68a1f420c98cbfe1d5f15227172d26bb7980338"
-  integrity sha512-9FoEnipA9hAgEp6oqIT3+hobF+JgIXIn5QV8kAB7QGxEDqs/pdpEbGc9qbxi0ghdjvqzOSDir9gNI3w0cL8Aug==
+"@aws-sdk/signature-v4@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.267.0.tgz"
+  integrity sha512-Je1e7rum2zvxa3jWfwq4E+fyBdFJmSJAwGtWYz3+/rWipwXFlSAPeSVqtNjHdfzakgabvzLp7aesG4yQTrO2YQ==
   dependencies:
     "@aws-sdk/is-array-buffer" "3.201.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     "@aws-sdk/util-hex-encoding" "3.201.0"
-    "@aws-sdk/util-middleware" "3.254.0"
+    "@aws-sdk/util-middleware" "3.267.0"
     "@aws-sdk/util-uri-escape" "3.201.0"
     "@aws-sdk/util-utf8" "3.254.0"
     tslib "^2.3.1"
 
-"@aws-sdk/smithy-client@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.254.0.tgz#053bb490fe6db91ce90471e285e37c8adb77440c"
-  integrity sha512-SI0jz9JfWi1IaakDX/26xliKTIMJpzwwDoyQPEfZ/L0KKdpr2gNhljA3sR2pZ2EM1oqOaXpMHAunSzv7EBpBWg==
+"@aws-sdk/smithy-client@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.267.0.tgz"
+  integrity sha512-WdgXHqKmFQIkAWETO/I5boX9u6QbMLC4X74OVSBaBLhRjqYmvolMFtNrQzvSKGB3FaxAN9Do41amC0mGoeLC8A==
   dependencies:
-    "@aws-sdk/middleware-stack" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/middleware-stack" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/token-providers@3.256.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.256.0.tgz#a07ddab7649ff70ccb5dc419d0d457553531dc56"
-  integrity sha512-R8FnhJShIJsvmDzTG2y8WrJYijY7cmK2G4VqqhOx34jCuDFM1/Ml8BzN/o2RvHzJH/7qCqfUMTsJEpt+KOuMPA==
+"@aws-sdk/token-providers@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.267.0.tgz"
+  integrity sha512-CGayGrPl4ONG4RuGbNv+QS4oVuItx4hK2FCbFS7d6V7h53rkDrcFd34NsvbicQ2KVFobE7fKs6ZaripJbJbLHA==
   dependencies:
-    "@aws-sdk/client-sso-oidc" "3.256.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/shared-ini-file-loader" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/client-sso-oidc" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/shared-ini-file-loader" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/types@3.254.0", "@aws-sdk/types@^3.222.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.254.0.tgz#760b4a876efa2edcec191dd8b18b989fa717a42e"
-  integrity sha512-xDEDk6ZAGFO0URPgB6R2mvQANYlojHLjLC9zzOzl07F+uqYS30yZDIg4UFcqPt/x48v7mxlKZpbaZgYI2ZLgGA==
+"@aws-sdk/types@3.267.0", "@aws-sdk/types@^3.222.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.267.0.tgz"
+  integrity sha512-fICTbSeIfXlTHnciQgDt37R0kXoKxgh0a3prnLWVvTcmf7NFujdZmg5YTAZT3KJJ7SuKsIgnI8azBYioVY8BVQ==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/url-parser@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.254.0.tgz#4b1fd769a4c546bd6571181feac2be1e8feaacab"
-  integrity sha512-Za0JGUa9p5GQ8t2tVtKaRSjLUxrmEdnBlUiZ2zKm86wFxgQnjbMwzD3mvyJ5OaVsXScU5vzc3CXHIXSvS7h7Ng==
+"@aws-sdk/url-parser@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.267.0.tgz"
+  integrity sha512-xoQ5Fd11moiE82QTL9GGE6e73SFuD0Wi73tA75TAwKuY12OP5vDJ4oBC86A1G2T+OzeHJQmYyqiA5j48CzqB6A==
   dependencies:
-    "@aws-sdk/querystring-parser" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/querystring-parser" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-base64@3.208.0":
   version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz#36b430e5396251f761590f7c2f0c5c12193f353c"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz"
   integrity sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==
   dependencies:
     "@aws-sdk/util-buffer-from" "3.208.0"
@@ -606,21 +602,21 @@
 
 "@aws-sdk/util-body-length-browser@3.188.0":
   version "3.188.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz#e1d949318c10a621b38575a9ef01e39f9857ddb0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz"
   integrity sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==
   dependencies:
     tslib "^2.3.1"
 
 "@aws-sdk/util-body-length-node@3.208.0":
   version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz#baabd1fa1206ff2bd4ce3785122d86eb3258dd20"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz"
   integrity sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==
   dependencies:
     tslib "^2.3.1"
 
 "@aws-sdk/util-buffer-from@3.208.0":
   version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz#285e86f6dc9030148a4147d65239e75cb254a1b0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz"
   integrity sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==
   dependencies:
     "@aws-sdk/is-array-buffer" "3.201.0"
@@ -628,132 +624,124 @@
 
 "@aws-sdk/util-config-provider@3.208.0":
   version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz#c485fd83fbac051337e5f6be60ea3f9fa61c0139"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz"
   integrity sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/util-defaults-mode-browser@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.254.0.tgz#6baa31a48521f2758f919130e0bd5180b179c7ad"
-  integrity sha512-vj/s+BuqNKTHN9bsZ/HY7vpBWbo3F+4c3/ZoKSZa5Jc7jAuGCbx3zWwHdJFDgvbqLvsTBw80Q9d/CDy9pKj/tQ==
+"@aws-sdk/util-defaults-mode-browser@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.267.0.tgz"
+  integrity sha512-MgrqpedA58HVR8RpT2A42//5Lb3M0JwEiYlDaA7EvIVsMx1NzO+cng4MDJi03YBAP5hwCVQmO9Sf5Au4dm+m0g==
   dependencies:
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     bowser "^2.11.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-defaults-mode-node@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.254.0.tgz#e92b3196ddc93fe5851b584aa5ac7fb22215d0ba"
-  integrity sha512-gvD2+Uf60c2BgUYv2d6R4dSpO/CbvybqblgF8lKZCsHkDWzfEdPv9nlJgUWM1cuMKQ0hBZ3cL3ilOwVKRVPyiQ==
+"@aws-sdk/util-defaults-mode-node@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.267.0.tgz"
+  integrity sha512-JyFk95T77sGM4q386id/mDt9/7HvoQySAygPyv/lj//WEJJIRKiefB277CKKJPT8nRAsO4mIyAT+YO/xGCxkQA==
   dependencies:
-    "@aws-sdk/config-resolver" "3.254.0"
-    "@aws-sdk/credential-provider-imds" "3.254.0"
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/property-provider" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/config-resolver" "3.267.0"
+    "@aws-sdk/credential-provider-imds" "3.267.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/property-provider" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-dynamodb@^3.245.0":
-  version "3.256.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-dynamodb/-/util-dynamodb-3.256.0.tgz#0516e02cc0c5c7f102256eb94877ed6b844004e2"
-  integrity sha512-DRyy48j5mgMlANJ8DLruEqhcml6P1bAtnxbbeKTl8fu0ro5WWeIEWK7so8wwfeijD9zxc98lN9HMtsElijOJvA==
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.267.0.tgz"
+  integrity sha512-qbQdr6DG+2EP9akTYdrOguDloBQozGpMQv4XH3Fb8H4pnW3s/Ml9caLmRFdvQGQV5vWJNLtkmCEMvxDqiQxGCA==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/util-endpoints@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.254.0.tgz#b21eed05e60210ac533ed96784d039015295895d"
-  integrity sha512-BzBIOnhVrs4RFTpGZErZfAV1VhqWglxn047VYijmCQe8Aejq4mJAaepSwHYar++XC0+pduD5YO8IidW8z/1vQQ==
+"@aws-sdk/util-endpoints@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.267.0.tgz"
+  integrity sha512-c6miY83Eo0erqXY+YiS2sOg3izURqvaWHd9przJzBQea9XRCN4ANT2P8AhoC0BPIORutaaOSoCSp/crHG0XLLg==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-hex-encoding@3.201.0":
   version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz#21d7ec319240ee68c33d938e71cb79830bea315d"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz"
   integrity sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==
   dependencies:
     tslib "^2.3.1"
 
 "@aws-sdk/util-locate-window@^3.0.0":
   version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz#0f598fc238a1256e4bcb64d01459f03a922dd4c3"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz"
   integrity sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/util-middleware@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.254.0.tgz#17e8c578c3905753aeb44289885d48fc6e16c864"
-  integrity sha512-gn7vInNTRBo2QatOB+uU99JwV53wf/zlTUnUK0qOuebtSDLMdiO+msiMi2ctz9vMIrtc2XMXNQro1aE0aUPy4w==
+"@aws-sdk/util-middleware@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.267.0.tgz"
+  integrity sha512-7nvqBZVz3RdwYv6lU958g6sWI2Qt8lzxDVn0uwfnPH+fAiX7Ln1Hen2A0XeW5cL5uYUJy6wNM5cyfTzFZosE0A==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/util-retry@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-retry/-/util-retry-3.254.0.tgz#c4cdf051439b4c12d1865dd2944b9eeb1d489bcc"
-  integrity sha512-IVA4wAOJpVssEIbJmeq1fdDYvrkOqYFK9Pz4tERmMz33003fyY92dU468Lulw8MnsSALYiwWUoWSFg9L5RCTug==
+"@aws-sdk/util-retry@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.267.0.tgz"
+  integrity sha512-ZXo1ICG2HgxkIZWlnPteh2R90kwmhRwvbP282CwrrYgTKuMZmW2R/+o6vqhWyPkjoNFN/pno0FxuDA3IYau3Sw==
   dependencies:
-    "@aws-sdk/service-error-classification" "3.254.0"
+    "@aws-sdk/service-error-classification" "3.267.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-uri-escape@3.201.0":
   version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz#5e708d4cde001a4558ee616f889ceacfadd2ab03"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz"
   integrity sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/util-user-agent-browser@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.254.0.tgz#a1e7783d4210eb6f4cfda3e6c9403e4a565f8244"
-  integrity sha512-2HvwH8l7ln4qTDsU3rgH9NvSSo5qhX+2Lenb6XvNnIMkL4r/tPhNIaGKtoQRfpzLH378Mm9XEQnJM5UXFRWuTA==
+"@aws-sdk/util-user-agent-browser@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.267.0.tgz"
+  integrity sha512-SmI6xInnPPa0gFhCqhtWOUMTxLeRbm7X5HXzeprhK1d8aNNlUVyALAV7K8ovIjnv3a97lIJSekyb78oTuYITCA==
   dependencies:
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/types" "3.267.0"
     bowser "^2.11.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-user-agent-node@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.254.0.tgz#044de697c3e7d151ecb80ccef529fec345e4c440"
-  integrity sha512-6nc9bmRP+2JqbBJ5oRZZRU8l35X3VcWF5j8XvmamWjIABsanc6Gv6NV4qAa3imPjIyWNiShZn/YkTBYs1exsdg==
+"@aws-sdk/util-user-agent-node@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.267.0.tgz"
+  integrity sha512-nfmyffA1yIypJ30CIMO6Tc16t8dFJzdztzoowjmnfb8/LzTZECERM3GICq0DvZDPfSo+jbuz634VtS2K7tVZjA==
   dependencies:
-    "@aws-sdk/node-config-provider" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/node-config-provider" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-utf8-browser@3.188.0", "@aws-sdk/util-utf8-browser@^3.0.0":
-  version "3.188.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz#484762bd600401350e148277731d6744a4a92225"
-  integrity sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==
+"@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.259.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz"
+  integrity sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==
   dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-utf8-node@3.208.0":
-  version "3.208.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz#eba17de0f92f87b98481c2e2d0ceaa05c7994d67"
-  integrity sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "3.208.0"
     tslib "^2.3.1"
 
 "@aws-sdk/util-utf8@3.254.0":
   version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz#909af9c6549833a9a9bf77004b7484bfc96b2c35"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz"
   integrity sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==
   dependencies:
     "@aws-sdk/util-buffer-from" "3.208.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-waiter@3.254.0":
-  version "3.254.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-waiter/-/util-waiter-3.254.0.tgz#b506286e9df90dcc02aaf99c958f57f99435a316"
-  integrity sha512-A9w23+tat+xkYdV1GprATue3JD8TzcdRxXsNOh4n33L3Xd6l3blXxPJjgi1wAVAeXy7Q8Lku7rsAc+YgKZ059w==
+"@aws-sdk/util-waiter@3.267.0":
+  version "3.267.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.267.0.tgz"
+  integrity sha512-umiVrTy2kAhWItvv5e4jPDYXnch88eT1uZ2lco9BttE63/MqC8ulNni45BQVvr95cVpYncZ/lH+7HTuEHzUHaw==
   dependencies:
-    "@aws-sdk/abort-controller" "3.254.0"
-    "@aws-sdk/types" "3.254.0"
+    "@aws-sdk/abort-controller" "3.267.0"
+    "@aws-sdk/types" "3.267.0"
     tslib "^2.3.1"
 
 "@babel/code-frame@7.12.11":
@@ -1482,9 +1470,9 @@ aws-sdk@2.1261.0:
     xml2js "0.4.19"
 
 aws-sdk@^2.1264.0:
-  version "2.1300.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1300.0.tgz#40190f3ccea8693c3764edab7aa5bd26db350fa7"
-  integrity sha512-1pz/+Kot+kTiH0WDH5A8Ao06dwz73xX6oCIpTbGTt/AKdmGTC8aAkMbk+KXoQatJSsQyqqxrtWIeKIQUaeUYDw==
+  version "2.1311.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1311.0.tgz"
+  integrity sha512-X3cFNsfs3HUfz6LKiLqvDTO4EsqO5DnNssh9SOoxhwmoMyJ2et3dEmigO6TaA44BjVNdLW98+sXJVPTGvINY1Q==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1557,7 +1545,7 @@ boolbase@^1.0.0:
 
 bowser@^2.11.0:
   version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  resolved "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
@@ -1810,7 +1798,7 @@ concurrently@^6.5.1:
 
 connect-dynamodb@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/connect-dynamodb/-/connect-dynamodb-2.0.6.tgz#df061de14b6e5e6c255685e8424a3323f03bed1b"
+  resolved "https://registry.npmjs.org/connect-dynamodb/-/connect-dynamodb-2.0.6.tgz"
   integrity sha512-M8aWGGrE6WkmxEQTdf6f2r0QLSiju1eaC/eeL4UT5tjj8QwV6IbfDxNEWSPbepoEQ8pYh8h9zV1e35YO9qMh2g==
   dependencies:
     connect "*"
@@ -1819,7 +1807,7 @@ connect-dynamodb@^2.0.6:
 
 connect@*:
   version "3.7.0"
-  resolved "https://registry.yarnpkg.com/connect/-/connect-3.7.0.tgz#5d49348910caa5e07a01800b030d0c35f20484f8"
+  resolved "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz"
   integrity sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
   dependencies:
     debug "2.6.9"
@@ -1865,6 +1853,7 @@ cookie@0.4.1:
 cookie@0.4.2:
   version "0.4.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cookiejar@^2.1.2:
   version "2.1.4"
@@ -1968,6 +1957,7 @@ dateformat@^4.6.3:
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
@@ -2309,7 +2299,7 @@ events@1.1.1:
 
 express-session@^1.17.3:
   version "1.17.3"
-  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.3.tgz#14b997a15ed43e5949cb1d073725675dd2777f36"
+  resolved "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz"
   integrity sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==
   dependencies:
     cookie "0.4.2"
@@ -2405,7 +2395,7 @@ fast-url-parser@^1.1.3:
 
 fast-xml-parser@4.0.11:
   version "4.0.11"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz"
   integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
   dependencies:
     strnum "^1.0.5"
@@ -2434,8 +2424,7 @@ fill-range@^7.0.1:
 
 finalhandler@1.1.2, finalhandler@~1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
-  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz"
   dependencies:
     debug "2.6.9"
     encodeurl "~1.0.2"
@@ -2538,6 +2527,7 @@ fs.realpath@^1.0.0:
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2967,7 +2957,7 @@ jmespath@0.16.0:
 
 jose@^4.10.0, jose@^4.9.2:
   version "4.11.2"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.2.tgz#d9699307c02e18ff56825843ba90e2fae9f09e23"
+  resolved "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz"
 
 joycon@^3.0.0:
   version "3.0.1"
@@ -3045,6 +3035,7 @@ json-stringify-safe@^5.0.1:
 json5@2.2.3, json5@^2.1.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 just-extend@^4.0.2:
   version "4.2.1"
@@ -3217,6 +3208,7 @@ minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.2:
 minimist@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -3224,7 +3216,7 @@ mkdirp@^1.0.4:
 
 mnemonist@0.38.3:
   version "0.38.3"
-  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  resolved "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz"
   integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
   dependencies:
     obliterator "^1.6.1"
@@ -3262,6 +3254,7 @@ mri@1.1.4:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3406,7 +3399,7 @@ object-inspect@^1.9.0:
 
 obliterator@^1.6.1:
   version "1.6.1"
-  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  resolved "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz"
   integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 oidc-token-hash@^5.0.1:
@@ -3441,7 +3434,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
 
 openid-client@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.3.2.tgz#fcc2c16f9681fa5f03ee0581b0935f88fc49f11f"
+  resolved "https://registry.npmjs.org/openid-client/-/openid-client-5.3.2.tgz"
   dependencies:
     jose "^4.10.0"
     lru-cache "^6.0.0"
@@ -4151,7 +4144,7 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.
 
 strnum@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  resolved "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 superagent@^6.1.0:
@@ -4296,13 +4289,12 @@ ts-node@^10.4.0:
 
 tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
 
 tslib@^2.3.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsscmp@1.0.6:
   version "1.0.6"
@@ -4415,6 +4407,7 @@ utils-merge@1.0.1:
 uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 uuid@^3.3.3:
   version "3.4.0"


### PR DESCRIPTION
## Proposed changes
re-merge (revert the revert) for [GUA-593] Customise Delete Screen 
(original PR https://github.com/alphagov/di-account-management-frontend/pull/851)

Also contains a fix for accounts and services being displayed that were not on the lists of allowed services. 

### What changed
Change between this PR and the original PR can be seen in the commits. Now services retrieved from the DB are filtered and must be present in the hard-coded lists of services and accounts. -  See new function in YourServices and how getServices is no longer exported so can't be called outside of the YourServices.ts file. 

[GUA-593]: https://govukverify.atlassian.net/browse/GUA-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### How to review 
Look at the second commit on this PR (4cd6e)
- Start by looking at the new function getAllowedListServices in yourServices.ts
- Next look at where this function is called within the delete-account-controller