### PR TITLE
GUA-696: tweak header hierarchy and add tests

### DIFF
--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% set pageTitleName = 'pages.yourServices.title' | translate %}
 {% set activeNav = 'your-services' %}
+{% set showSecondaryHeadings = servicesList.length and accountsList.length %}
+{% set serviceHeadingLevel =  "h3" if showSecondaryHeadings else "h2" %}
 
 {% block content %}
   <div class="govuk-grid-row" id="your-services">
@@ -15,22 +17,22 @@
       {% if not (servicesList.length or accountsList.length) %}
         {# Display an empty state when no accounts nor services have been used #}
         {# This should be an edge case as the only pathways into the account would be signing up via other services #}
-      <div class="your-services__card your-services__card--empty">
+      <div class="your-services__card your-services__card--empty" data-test-id="empty-state">
         <div class="your-services__card__content">
           <p class="govuk-body">{{ 'pages.yourServices.empty' | translate }}</p>
         </div>
       </div>
       {% endif %}
-      {% if servicesList.length and accountsList.length %}
+      {% if showSecondaryHeadings %}
         {# Show heading ONLY when there are both accounts and services #}
-        <h2 class="govuk-heading-m">{{ 'pages.yourServices.accountsList.heading' | translate }}</h2>
+        <h2 class="govuk-heading-m" data-test-id="accounts-heading">{{ 'pages.yourServices.accountsList.heading' | translate }}</h2>
       {% endif %}
       {% if accountsList.length %}
-      <ul class="govuk-list your-services__list">
+      <ul class="govuk-list your-services__list ">
         {% for account in accountsList %}
           {% set locale = ['pages.yourServices.clientRegistry.', env, '.', account.client_id, '.'] | join %}
           <li class="your-services__card">
-            <h3 class="govuk-heading-s your-services__card__heading">{{ [locale, 'header'] | join | translate }}</h2>
+            <{{serviceHeadingLevel}} class="govuk-heading-s your-services__card__heading" data-test-id="account-card-heading">{{ [locale, 'header'] | join | translate }}</{{serviceHeadingLevel}}>
             <div class="your-services__card__content">
               <p class="govuk-body">{{ [locale, 'description'] | join | translate }}</p>
               <p class="govuk-body">
@@ -42,9 +44,9 @@
         {% endfor %}
       </ul>
       {% endif %}
-      {% if servicesList.length and accountsList.length %}
+      {% if showSecondaryHeadings %}
         {# Show heading ONLY when there are both accounts and services #}
-        <h2 class="govuk-heading-m">{{ 'pages.yourServices.servicesList.heading' | translate }}</h2>
+        <h2 class="govuk-heading-m" data-test-id="services-heading">{{ 'pages.yourServices.servicesList.heading' | translate }}</h2>
       {% endif %}
       {% if servicesList.length %}
       <ul class="govuk-list your-services__list">
@@ -52,9 +54,9 @@
           {% set locale = ['pages.yourServices.clientRegistry.', env, '.', service.client_id, '.'] | join %}
           <li class="your-services__card">
             <div class="your-services__card__content">
-            <h3 class="govuk-heading-s govuk-!-font-weight-regular">
+            <{{serviceHeadingLevel}} class="govuk-heading-s govuk-!-font-weight-regular" data-test-id="service-card-heading">
               <a class="govuk-link" href="{{ [locale, 'link_href'] | join | translate }}">{{ [locale, 'link_text'] | join | translate }}</a>
-            </h3>
+            </{{serviceHeadingLevel}}>
             <p class="govuk-body your-services__card__last-used">{{ 'pages.yourServices.lastUsed' | translate }}: {{ service.last_accessed_readable_format }}</p>
             </div>
           </li>
@@ -65,6 +67,7 @@
         <h2 class="govuk-heading-m">{{ 'pages.yourServices.informationBox.heading' | translate }}</h2>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph1' | translate }}</p>
         <ul class="govuk-list govuk-list--bullet">
+
           <li>{{ 'pages.yourServices.informationBox.listItem1' | translate }}</li>
           <li>{{ 'pages.yourServices.informationBox.listItem2' | translate }}</li>
           <li>{{ 'pages.yourServices.informationBox.listItem3' | translate }}</li>

--- a/src/components/your-services/tests/your-services-integration.test.ts
+++ b/src/components/your-services/tests/your-services-integration.test.ts
@@ -1,0 +1,126 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { expect, sinon } from "../../../../test/utils/test-utils";
+import * as cheerio from "cheerio";
+import * as nock from "nock";
+import decache from "decache";
+import { PATH_DATA } from "../../../app.constants";
+
+const { url } = PATH_DATA.YOUR_SERVICES;
+
+const DEFAULT_USER_SESSION = {
+  email: "test@test.com",
+  isAuthenticated: true,
+  subjectId: "asdf",
+  state: {},
+  tokens: {
+    accessToken: "token",
+    idToken: "Idtoken",
+    refreshToken: "token",
+  },
+};
+
+describe("Integration:: your services", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  it("should display an empty state when no services have been added", async () => {
+    const app = await appWithMiddlewareSetup();
+    await request(app)
+      .get(url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect(res.status).to.equal(200);
+        expect($("[data-test-id='empty-state']").length).to.not.equal(0);
+      });
+  });
+
+  it("should display accounts without a section heading when only accounts but not services have been added", async () => {
+    const app = await appWithMiddlewareSetup({hasAccounts: true});
+    await request(app)
+      .get(url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect(res.status).to.equal(200);
+        expect($("h2[data-test-id='accounts-heading']").length).to.equal(0);
+        expect($("h2[data-test-id='account-card-heading']").length).to.not.equal(0);
+      });
+  });
+
+  it("should display services without a section heading when only services but not accounts have been added", async () => {
+    const app = await appWithMiddlewareSetup({hasServices: true});
+    await request(app)
+      .get(url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect(res.status).to.equal(200);
+        expect($("h2[data-test-id='services-heading']").length).to.equal(0);
+        expect($("h2[data-test-id='service-card-heading']").length).to.not.equal(0);
+      });
+  });
+
+
+  it("should display services and accounts with section headings when both services and accounts have been added", async () => {
+    const app = await appWithMiddlewareSetup({hasAccounts: true, hasServices: true});
+    await request(app)
+      .get(url)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect(res.status).to.equal(200);
+        expect($("h3[data-test-id='account-card-heading']").length).to.not.equal(0);
+        expect($("h3[data-test-id='service-card-heading']").length).to.not.equal(0);
+        expect($("h2[data-test-id='services-heading']").length).to.not.equal(0);
+        expect($("h2[data-test-id='accounts-heading']").length).to.not.equal(0);
+      });
+  });
+});
+
+const appWithMiddlewareSetup = async (data?: {hasAccounts?: boolean, hasServices?: boolean}) => {
+  decache("../../../app");
+  decache("../../../middleware/requires-auth-middleware");
+  const sandbox = sinon.createSandbox();
+  const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
+  const yourServices = require("../../../utils/yourServices");
+  const oidc = require("../../../utils/oidc");
+  const params = data || {};
+  const accounts = params.hasAccounts || false;
+  const services = params.hasServices || false;
+
+  sandbox
+    .stub(sessionMiddleware, "requiresAuthMiddleware")
+    .callsFake(function (req: any, res: any, next: any): void {
+      req.session.user = DEFAULT_USER_SESSION;
+      next();
+    });
+  
+  sandbox.stub(yourServices, "presentYourServices").callsFake(function() {
+    return {
+      accountsList: accounts ? [{
+        client_id: "gov-uk",
+        count_successful_logins: "1",
+        last_accessed: "",
+        last_accessed_readable_format: "",
+      }] : [],
+      servicesList: services ? [{
+        client_id: "dbs",
+        count_successful_logins: "1",
+        last_accessed: "",
+        last_accessed_readable_format: "",
+      }] : [],
+    };
+  })
+  sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
+    return new Promise((resolve) => {
+      resolve({});
+    });
+  });
+
+  sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    return new Promise((resolve) => {
+      resolve({});
+    });
+  });
+
+  return await require("../../../app").createApp();
+};


### PR DESCRIPTION
A google lighthouse report I ran on the service dashboard has highlighted that on the services dashboard heading levels are not in a sequential order when the user only has accounts/services due to the fact that heading hierarchy skips from `h1` to `h3`  ( the `h2`s “Your accounts“/“Your services“ are not displayed unless the user has both accounts and services on their dashboard).

![Screenshot 2023-02-27 at 17 28 44](https://user-images.githubusercontent.com/7116819/223471861-196bdd2e-f91d-455a-bff5-6b80541497db.png)


This introduces some simple logic which changes the heading level depending on context.

It also adds an integration test for **Your services** as the test was missing before.