### PR TITLE
BAU: Check for pinned versions by SHA when running github actions

### DIFF
--- a/.github/workflows/require-pinned-github-actions.yml
+++ b/.github/workflows/require-pinned-github-actions.yml
@@ -1,0 +1,13 @@
+on: push
+
+name: Require Pinned Github Actions
+
+jobs:
+  harden_security:
+    name: Harden Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@21991cec25093947ff3f62e4c223df0260c39944 # pin@v2

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,15 +6,16 @@ on:
       - main
   pull_request:
 
+
 jobs:
   sonarcloud:
     name: Run Sonar scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3
         with:
           node-version-file: .node-version
       - name: Install dependencies
@@ -22,7 +23,7 @@ jobs:
       - name: Generate coverage report
         run: npm run test:coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@db501078e936e4b4c8773d1bb949ba9ddb7b6b6a # pin@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/validate-docker-image-dev.yml
+++ b/.github/workflows/validate-docker-image-dev.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Image Checks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
@@ -37,14 +37,14 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # pin@v1
 
       - name: Build Docker Image
         id: build-image
@@ -56,7 +56,7 @@ jobs:
           docker build -t $DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$IMAGE_TAG .
 
       - name: Vulnerability Scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee # pin@master
         with:
           image-ref: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.DEV_ECR_REPOSITORY }}:latest
           format: "table"

--- a/.github/workflows/validate-docker-image.yml
+++ b/.github/workflows/validate-docker-image.yml
@@ -21,7 +21,7 @@ jobs:
     name: "Image Checks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
@@ -34,14 +34,14 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # pin@v1
 
       - name: Build Docker Image
         id: build-image
@@ -53,7 +53,7 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
       - name: Vulnerability Scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee # pin@master
         with:
           image-ref: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:latest
           format: "table"

--- a/.github/workflows/validate-sam-template-dev.yml
+++ b/.github/workflows/validate-sam-template-dev.yml
@@ -28,20 +28,20 @@ jobs:
       ENVIRONMENT: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
         with:
           python-version: "3.9"
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@b42eb7a54dac4039080975e32860b1b30935c9af # pin@v2
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2

--- a/.github/workflows/validate-sam-template.yml
+++ b/.github/workflows/validate-sam-template.yml
@@ -24,20 +24,20 @@ jobs:
       ENVIRONMENT: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
         with:
           python-version: "3.9"
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@b42eb7a54dac4039080975e32860b1b30935c9af # pin@v2
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2


### PR DESCRIPTION
Why? https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

But I agree with this:
https://michaelheap.com/improve-your-github-actions-security/

> I agree with Julien that using arbitary actions is a risk, but as
always it’s a compromise between security and making life easy for ourselves. Specifying a commit hash each time we want to upgrade could become painful very quickly, especially if you’re using a large number of actions.

With that in mind, I thought about how we could solve the problem with automation and came up with the following solution.

> TL;DR: Using GitHub actions with branch names or tags is unsafe.
Use commit hash instead

So let's add checks to pin github action versions to ones we trust enough to use, and then run the pin-github-action[2] tool to pin the new versions in this workflow