### PR TITLE
BAU pin action versions

### DIFF
--- a/.github/workflows/build-test-application.yml
+++ b/.github/workflows/build-test-application.yml
@@ -40,7 +40,7 @@ jobs:
         ports:
           - 4566:4566
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
@@ -55,7 +55,7 @@ jobs:
         shell: bash
 
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3
         with:
           node-version-file: .node-version
 

--- a/.github/workflows/build-test-application.yml
+++ b/.github/workflows/build-test-application.yml
@@ -49,8 +49,7 @@ jobs:
           AWS_DEFAULT_REGION: eu-west-2
           AWS_ACCESS_KEY_ID: na
           AWS_SECRET_ACCESS_KEY: na
-        run:
-          ./localstack/provision.sh
+        run: ./localstack/provision.sh
 
         shell: bash
 

--- a/.github/workflows/dev-instance.yml
+++ b/.github/workflows/dev-instance.yml
@@ -42,7 +42,7 @@ jobs:
       - validate_application
       - validate_deployment
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef }}
 
@@ -55,14 +55,14 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.DEV_INSTANCE_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # pin@v1
 
       - name: Build & Publish Docker Image as latest
         id: build-image

--- a/.github/workflows/on-manual-publish-to-dev.yml
+++ b/.github/workflows/on-manual-publish-to-dev.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Fetch Commit SHA by Tag
         id: gitRefTag
         if: ${{ github.event.inputs.choice }} == "Tag"
-        run : echo GIT_REF_SHA=$(git rev-list -n 1 ${{ inputs.gitRef }}) >> $GITHUB_ENV
+        run: echo GIT_REF_SHA=$(git rev-list -n 1 ${{ inputs.gitRef }}) >> $GITHUB_ENV
 
       - name: Set tag
         id: vars

--- a/.github/workflows/on-manual-publish-to-dev.yml
+++ b/.github/workflows/on-manual-publish-to-dev.yml
@@ -45,7 +45,7 @@ jobs:
       - validate_application
       - validate_deployment
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef }}
 
@@ -73,14 +73,14 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # pin@v1
 
       - name: Build & Publish Docker Image as latest
         id: build-image

--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -36,7 +36,7 @@ jobs:
     needs: validate_deployment
     steps:
       - name: "Push signed image to ECR, updated SAM template wih image then upload it to the S3 Artifact Bucket"
-        uses: alphagov/di-devplatform-upload-action-ecr@1.0.2
+        uses: alphagov/di-devplatform-upload-action-ecr@ba822356a0829c260379b66bcae6e3c5c7f00e42 # pin@1.0.2
         with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -7,6 +7,7 @@ on:
       - main
   workflow_dispatch:
 
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
Why? https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

But I agree with this:
https://michaelheap.com/improve-your-github-actions-security/

> I agree with Julien that using arbitary actions is a risk, but as
always it’s a compromise between security and making life easy for ourselves. Specifying a commit hash each time we want to upgrade could become painful very quickly, especially if you’re using a large number of actions.

With that in mind, I thought about how we could solve the problem with automation and came up with the following solution.

> TL;DR: Using GitHub actions with branch names or tags is unsafe.
Use commit hash instead

Runs the pin-github-action[2] tool across all our workflows to pin the new versions in this workflow

[2]: https://michaelheap.com/improve-your-github-actions-security/