### PR TITLE
GUA-723: move to drop down version of service list

### DIFF
--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -1,6 +1,8 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageTitleName = 'pages.yourServices.title' | translate %}
+{% set serviceLinks =  'pages.yourServices.informationBox.details.listItems' | translate({ returnObjects: true }) %}
 {% set activeNav = 'your-services' %}
 {% set showSecondaryHeadings = servicesList.length and accountsList.length %}
 {% set serviceHeadingLevel =  "h3" if showSecondaryHeadings else "h2" %}
@@ -63,20 +65,21 @@
         {% endfor %}
       </ul>
       {% endif %}
+      {% set detailsHTML %}
+        <p class="govuk-body">{{ 'pages.yourServices.informationBox.details.paragraph' | translate }}</p>
+         <ul class="govuk-list govuk-list--bullet">
+          {% for serviceLink in serviceLinks %}
+            <li><a class="govuk-link" href="{{ serviceLink["href"] }}">{{ serviceLink["text"] }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endset %}
       <div class="information-box">
         <h2 class="govuk-heading-m">{{ 'pages.yourServices.informationBox.heading' | translate }}</h2>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph1' | translate }}</p>
-        <ul class="govuk-list govuk-list--bullet">
-
-          <li>{{ 'pages.yourServices.informationBox.listItem1' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem2' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem3' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem4' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem5' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem6' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem7' | translate }}</li>
-          <li>{{ 'pages.yourServices.informationBox.listItem8' | translate }}</li>
-        </ul>
+        {{ govukDetails({
+          summaryText: 'pages.yourServices.informationBox.details.summary' | translate,
+          html: detailsHTML
+        }) }}
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph2' | translate }}</p>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph3' | translate }}</p>
       </div>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -170,16 +170,46 @@
         "heading": "Gwasanaethau eraill rydych wedi eu defnyddio"
       },
       "informationBox": {
-        "heading": "Am GOV.UK One Login",
-        "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond ei ddefnyddio gyda:",
-        "listItem1": "Gwneud cais am drwydded gweithredwr cerbyd",
-        "listItem2": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
-        "listItem3": "Tanysgrifiadau e-byst GOV.UK",
-        "listItem4": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
-        "listItem5": "Cofrestrfa datganiad caethwasiaeth modern",
-        "listItem6": "Cyfrif arbenigwr pwnc Ofqual",
-        "listItem7": "Gwneud cais am wiriad DBS sylfaenol",
-        "listItem8": "Llofnodwch eich gweithred morgais",
+        "heading": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login",
+        "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond ei ddefnyddio i gael mynediad i rai gwasanaethau'r llywodraeth.",
+        "details": {
+          "summary": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login",
+          "paragraph": "Gallwch ddefnyddio GOV.UK One Login gyda:",
+          "listItems": [
+            {
+              "text": "Gwneud cais am drwydded gweithredwr cerbyd",
+              "href": "https://www.gov.uk/apply-vehicle-operator-licence"
+            },
+            {
+              "text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
+              "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+            },
+            {
+              "text": "Tanysgrifiadau e-byst GOV.UK",
+              "href": "https://www.gov.uk/email/manage"
+            },
+            {
+              "text": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
+              "href": "https://exporter.lite.private-beta.service.trade.gov.uk/"
+            },
+            {
+              "text": "Cofrestrfa datganiad caethwasiaeth modern",
+              "href": "https://www.gov.uk/guidance/add-your-modern-slavery-statement-to-the-statement-registry"
+            },
+            {
+              "text": "Cyfrif arbenigwr pwnc Ofqual",
+              "href": "https://www.gov.uk/guidance/subject-matter-specialists-for-ofqual"
+            },
+            {
+              "text": "Gwneud cais am wiriad DBS sylfaenol",
+              "href": "https://www.gov.uk/request-copy-criminal-record"
+            },
+            {
+              "text": "Llofnodwch eich gweithred morgais",
+              "href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
+            }
+          ]
+        },
         "paragraph2": "Nid yw GOV.UK One Login yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
         "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich GOV.UK One Login i gael mynediad i holl wasanaethau ar GOV.UK."
       },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -202,7 +202,7 @@
             },
             {
               "text": "Gwneud cais am wiriad DBS sylfaenol",
-              "href": "https://www.gov.uk/request-copy-criminal-record"
+              "href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
             },
             {
               "text": "Llofnodwch eich gweithred morgais",
@@ -242,7 +242,7 @@
           "RqFZ83csmS4Mi4Y7s7ohD9-ekwU": {
             "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
-            "link_href": "https://www.gov.uk/request-copy-criminal-record"
+            "link_href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
           },
           "XwwVDyl5oJKtK0DVsuw3sICWkPU": {
             "header": "Gwneud cais am drwydded gweithredwr cerbyd",
@@ -287,7 +287,7 @@
           "Dw7Cxas8W7O2usHMHok95elKDRU": {
             "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
-            "link_href": "https://www.gov.uk/request-copy-criminal-record"
+            "link_href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
           },
           "oLciSn5b6-cqcJjzgMMwCw1moD8": {
             "header": "Gwneud cais am drwydded gweithredwr cerbyd",
@@ -333,7 +333,7 @@
           "dbs": {
             "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
-            "link_href": "https://www.gov.uk/request-copy-criminal-record"
+            "link_href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
           },
           "vehicleOperatorLicense": {
             "header": "Gwneud cais am drwydded gweithredwr cerbyd",
@@ -379,7 +379,7 @@
           "dbs": {
             "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
-            "link_href": "https://www.gov.uk/request-copy-criminal-record"
+            "link_href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
           },
           "vehicleOperatorLicense": {
             "header": "Gwneud cais am drwydded gweithredwr cerbyd",
@@ -425,7 +425,7 @@
           "dbs": {
             "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
-            "link_href": "https://www.gov.uk/request-copy-criminal-record"
+            "link_href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
           },
           "vehicleOperatorLicense": {
             "header": "Gwneud cais am drwydded gweithredwr cerbyd",
@@ -471,7 +471,7 @@
           "dbs": {
             "header": "Gwneud cais am wiriad DBS sylfaenol",
             "link_text": "Gwneud cais am wiriad DBS sylfaenol",
-            "link_href": "https://www.gov.uk/request-copy-criminal-record"
+            "link_href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
           },
           "vehicleOperatorLicense": {
             "header": "Gwneud cais am drwydded gweithredwr cerbyd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -170,16 +170,46 @@
         "heading": "Other services you’ve used"
       },
       "informationBox": {
-        "heading": "About GOV.UK One Login",
-        "paragraph1": "GOV.UK One Login is new. At the moment you can only use it with:",
-        "listItem1": "Apply for a vehicle operator licence",
-        "listItem2": "Apply to become a registered social worker in England",
-        "listItem3": "GOV.UK email subscriptions",
-        "listItem4": "LITE (Licensing for International Trade and Enterprise)",
-        "listItem5": "Modern slavery statement registry",
-        "listItem6": "Ofqual subject matter specialist account",
-        "listItem7": "Request a basic DBS check",
-        "listItem8": "Sign your mortgage deed",
+        "heading": "Services you can use with GOV.UK One Login",
+        "paragraph1": "GOV.UK One Login is new. At the moment you can only use it to access some government services.",
+        "details": {
+          "summary": "Services you can use with GOV.UK One Login",
+          "paragraph": "You can use GOV.UK One Login with:",
+          "listItems": [
+            {
+              "text": "Apply for a vehicle operator licence",
+              "href": "https://www.gov.uk/apply-vehicle-operator-licence"
+            },
+            {
+              "text": "Apply to become a registered social worker in England",
+              "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
+            },
+            {
+              "text": "GOV.UK email subscriptions",
+              "href": "https://www.gov.uk/email/manage"
+            },
+            {
+              "text": "LITE (Licensing for International Trade and Enterprise)",
+              "href": "https://exporter.lite.private-beta.service.trade.gov.uk/"
+            },
+            {
+              "text": "Modern slavery statement registry",
+              "href": "https://www.gov.uk/guidance/add-your-modern-slavery-statement-to-the-statement-registry"
+            },
+            {
+              "text": "Ofqual subject matter specialist account",
+              "href": "https://www.gov.uk/guidance/subject-matter-specialists-for-ofqual"
+            },
+            {
+              "text": "Request a basic DBS check",
+              "href": "https://www.gov.uk/request-copy-criminal-record"
+            },
+            {
+              "text": "Sign your mortgage deed",
+              "href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
+            }
+          ]
+        },
         "paragraph2": "GOV.UK One Login does not work with all government accounts and services yet (for example Government Gateway or Universal Credit).",
         "paragraph3": "In the future, you'll be able to use GOV.UK One Login to access all services on GOV.UK."
       },


### PR DESCRIPTION
As the list of services onboarded with One Login is becoming longer, it is also becoming less manageable.
This updates the list to a drop down design where the list of services is hidden by default.

Design in Figma: https://www.figma.com/file/0JbNRTnq5ibRtfg8BMxXDL/Accounts-design-thinking?node-id=1494-14364&t=ki5KV1a2TUjCVKwz-4

Also corrects the Welsh language version of the DBS link –  it should be linking to the Welsh version of the service, not the English one.