### PR TITLE
BAU: Update i18next to v22.4.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "express-validator": "^6.13.0",
         "govuk-frontend": "^4.5.0",
         "helmet": "4.6.0",
-        "i18next": "^21.5.4",
+        "i18next": "^22.4.13",
         "i18next-fs-backend": "^1.1.4",
         "i18next-http-middleware": "^3.1.4",
         "jose": "^4.9.2",
@@ -1720,11 +1720,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2089,6 +2089,29 @@
       "license": "MIT",
       "dependencies": {
         "i18next": "^21.0.1"
+      }
+    },
+    "node_modules/@types/i18next-fs-backend/node_modules/i18next": {
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "node_modules/@types/json-schema": {
@@ -5174,11 +5197,25 @@
       }
     },
     "node_modules/i18next": {
-      "version": "21.5.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.5.4.tgz",
-      "license": "MIT",
+      "version": "22.4.13",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.13.tgz",
+      "integrity": "sha512-GX7flMHRRqQA0I1yGLmaZ4Hwt1JfLqagk8QPDPZsqekbKtXsuIngSVWM/s3SLgNkrEXjA+0sMGNuOEkkmyqmWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
       "dependencies": {
-        "@babel/runtime": "^7.12.0"
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/i18next-fs-backend": {
@@ -7236,9 +7273,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "license": "MIT"
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "express-validator": "^6.13.0",
     "govuk-frontend": "^4.5.0",
     "helmet": "4.6.0",
-    "i18next": "^21.5.4",
+    "i18next": "^22.4.13",
     "i18next-fs-backend": "^1.1.4",
     "i18next-http-middleware": "^3.1.4",
     "jose": "^4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,6 +903,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.20.6":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.15.4":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
@@ -2728,11 +2735,18 @@ i18next-http-middleware@^3.1.4:
   version "3.1.4"
   resolved "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.1.4.tgz"
 
-i18next@^21.0.1, i18next@^21.5.4:
+i18next@^21.0.1:
   version "21.5.4"
   resolved "https://registry.npmjs.org/i18next/-/i18next-21.5.4.tgz"
   dependencies:
     "@babel/runtime" "^7.12.0"
+
+i18next@^22.4.13:
+  version "22.4.14"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-22.4.14.tgz#18dd94e9adc2618497c7de101a206e1ca3a18727"
+  integrity sha512-VtLPtbdwGn0+DAeE00YkiKKXadkwg+rBUV+0v8v0ikEjwdiJ0gmYChVE4GIa9HXymY6wKapkL93vGT7xpq6aTw==
+  dependencies:
+    "@babel/runtime" "^7.20.6"
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -3808,6 +3822,11 @@ readdirp@~3.6.0:
 real-require@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"


### PR DESCRIPTION
Seems the breaking change here was about typescript definitions.
But seems internal to them 🤔 

So if this compiles then OK:

See here: https://github.com/i18next/i18next/releases/tag/v22.0.0