### PR TITLE
BAU: Stop depbot suggesting alpine 19 node version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       - dependencies
     ignore:
       - dependency-name: "node"
-        versions: ["17.x", "18.x"]
+        versions: ["17.x", "18.x", "19.x"]
     commit-message:
       prefix: BAU
   - package-ecosystem: docker


### PR DESCRIPTION
We're not ready to make that leap yet and it adds PR noise

see here: https://github.com/alphagov/di-account-management-frontend/pull/870