### PR TITLE
GUA-760: Refactor integration tests

### DIFF
--- a/src/components/change-email/index.njk
+++ b/src/components/change-email/index.njk
@@ -23,6 +23,7 @@
     name: "email",
     value: email,
     errorMessage: {
+        attributes: { "data-test-id": "email-error"},
         text: errors['email'].text
     } if (errors['email'])})
 }}

--- a/src/components/change-email/tests/change-email-integration.test.ts
+++ b/src/components/change-email/tests/change-email-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -108,7 +109,7 @@ describe("Integration:: change email", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#email-error").text()).to.contains(
+        expect($(testComponent('email-error')).text()).to.contains(
           "Enter your email address"
         );
       })
@@ -126,7 +127,7 @@ describe("Integration:: change email", () => {
       })
       .expect(function (res) {
         const page = cheerio.load(res.text);
-        expect(page("#email-error").text()).to.contains(
+        expect(page(testComponent('email-error')).text()).to.contains(
           "Enter an email address in the correct format, like name@example.com"
         );
       })
@@ -144,7 +145,7 @@ describe("Integration:: change email", () => {
       })
       .expect(function (res) {
         const page = cheerio.load(res.text);
-        expect(page("#email-error").text()).to.contains(
+        expect(page(testComponent('email-error')).text()).to.contains(
           "You are already using that email address. Enter a different email address."
         );
       })
@@ -163,7 +164,7 @@ describe("Integration:: change email", () => {
       })
       .expect(function (res) {
         const page = cheerio.load(res.text);
-        expect(page("#email-error").text()).to.contains(
+        expect(page(testComponent('email-error')).text()).to.contains(
           "There’s already a GOV.UK One Login using that email address. Enter a different email address."
         );
       })

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import nock = require("nock");
 import { load } from "cheerio";
 import decache from "decache";
@@ -107,10 +108,10 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "Enter your new password"
         );
-        expect($("#confirm-password-error").text()).to.contains(
+        expect($(testComponent('confirm-password-error')).text()).to.contains(
           "Re-type your new password"
         );
       })
@@ -129,7 +130,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#confirm-password-error").text()).to.contains(
+        expect($(testComponent('confirm-password-error')).text()).to.contains(
           "Enter the same password in both fields"
         );
       })
@@ -148,7 +149,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
@@ -167,7 +168,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
@@ -191,7 +192,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers"
         );
       })
@@ -210,7 +211,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
@@ -234,7 +235,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "You are already using that password. Enter a different password"
         );
       })
@@ -258,9 +259,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(".govuk-heading-l").text()).to.contains(
-          "Sorry, there is a problem with the service"
-        );
+        expect($(testComponent('error-heading')).text()).to.not.be.empty;
       })
       .expect(500, done);
   });

--- a/src/components/change-phone-number/index.njk
+++ b/src/components/change-phone-number/index.njk
@@ -28,7 +28,8 @@
   type: "tel",
   autocomplete: "tel",
   errorMessage: {
-  text: errors['phoneNumber'].text
+    attributes: { "data-test-id": "phoneNumber-error"},
+    text: errors['phoneNumber'].text
   } if (errors['phoneNumber'])})
   }}
 
@@ -46,7 +47,8 @@
         text: 'pages.changePhoneNumber.internationalPhoneNumber.hint' | translate
       },
       errorMessage: {
-      text: errors['internationalPhoneNumber'].text
+        attributes: { "data-test-id": "internationalPhoneNumber-error"},
+        text: errors['internationalPhoneNumber'].text
       } if (errors['internationalPhoneNumber'])
     }) }}
   {% endset -%}

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -110,7 +111,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
+        expect($(testComponent('phoneNumber-error')).text()).to.contains(
           "Enter a UK mobile phone number"
         );
       })
@@ -128,7 +129,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
+        expect($(testComponent('phoneNumber-error')).text()).to.contains(
           "Enter a UK mobile phone number"
         );
       })
@@ -146,7 +147,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
+        expect($(testComponent('phoneNumber-error')).text()).to.contains(
           "Enter a UK mobile phone number using only numbers or the + symbol"
         );
       })
@@ -164,7 +165,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
+        expect($(testComponent('phoneNumber-error')).text()).to.contains(
           "Enter a UK mobile phone number, like 07700 900000"
         );
       })
@@ -182,7 +183,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
+        expect($(testComponent('phoneNumber-error')).text()).to.contains(
           "Enter a UK mobile phone number, like 07700 900000"
         );
       })
@@ -276,10 +277,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
+        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
           "Enter a mobile phone number"
         );
-        expect($("#phoneNumber-error").text()).to.contains("");
+        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -301,10 +302,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
+        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
           "You’re already using that phone number. Enter a different phone number."
         );
-        expect($("#phoneNumber-error").text()).to.contains("");
+        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -325,7 +326,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
+        expect($(testComponent('phoneNumber-error')).text()).to.contains(
           "You’re already using that phone number. Enter a different phone number."
         );
       })
@@ -344,10 +345,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
+        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
           "Enter a mobile phone number in the correct format, including the country code"
         );
-        expect($("#phoneNumber-error").text()).to.contains("");
+        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -364,10 +365,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
+        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
           "Enter a mobile phone number using only numbers or the + symbol"
         );
-        expect($("#phoneNumber-error").text()).to.contains("");
+        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -384,10 +385,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
+        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
           "Enter a mobile phone number in the correct format, including the country code"
         );
-        expect($("#phoneNumber-error").text()).to.contains("");
+        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -404,10 +405,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
+        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
           "Enter a mobile phone number in the correct format, including the country code"
         );
-        expect($("#phoneNumber-error").text()).to.contains("");
+        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
       })
       .expect(400, done);
   });

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -37,7 +37,8 @@
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: {
-        text: errors['code'].text
+        text: errors['code'].text,
+        attributes: { "data-test-id": "code-error"}
     } if (errors['code'])})
 }}
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -31,7 +31,8 @@
             inputmode: "numeric",
             spellcheck: false,
             errorMessage: {
-                text: errors['code'].text
+                text: errors['code'].text,
+                attributes: { "data-test-id": "code-error"}
             } if (errors['code'])})
         }}
 

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -106,7 +107,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($(testComponent('code-error')).text()).to.contains("Enter the security code");
       })
       .expect(400, done);
   });
@@ -122,7 +123,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
+        expect($(testComponent('code-error')).text()).to.contains(
           "Enter the security code using only 6 digits"
         );
       })
@@ -140,7 +141,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
+        expect($(testComponent('code-error')).text()).to.contains(
           "Enter the security code using only 6 digits"
         );
       })
@@ -158,7 +159,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
+        expect($(testComponent('code-error')).text()).to.contains(
           "Enter the security code using only 6 digits"
         );
       })
@@ -193,7 +194,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
+        expect($(testComponent('code-error')).text()).to.contains(
           "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
         );
       })

--- a/src/components/common/errors/500.njk
+++ b/src/components/common/errors/500.njk
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">{{ 'error.error500.header' | translate }}</h1>
+      <h1 class="govuk-heading-l" data-test-id="error-heading">{{ 'error.error500.header' | translate }}</h1>
       <p class="govuk-body">{{ 'error.error500.content.paragraph1' | translate }}</p>
     </div>
   </div>

--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -12,7 +12,8 @@
             type: "password",
             spellcheck: false,
             errorMessage: {
-                text: errors[id].text
+                text: errors[id].text,
+                attributes: { "data-test-id": id + "-error"}
             } if (errors[id])})
         }}
     </div>

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -19,20 +19,20 @@
     {% for service in services %}
 
       {% set locale = ['pages.yourServices.clientRegistry.', env, '.', service.client_id, '.'] | join %}
-        <li id="service-list-item">{{ [locale, 'header'] | join | translate }}</li>
+        <li data-test-id="service-list-item">{{ [locale, 'header'] | join | translate }}</li>
 
     {% endfor %}
     </ul>
     {% if hasGovUkEmailSubscription %}
-      <p class="govuk-body" id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
+      <p class="govuk-body" data-test-id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
     {% endif %}
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph4b' | translate }}</p>
   {% endif %}
 
   {% if not services.length %}
-<p class="govuk-body", id="no-services-content">{{ 'pages.deleteAccount.paragraph4a' | translate }}</p>
- {% endif %}
-<p class="govuk-body">{{ 'pages.deleteAccount.paragraph5' | translate }}</p>
+    <p class="govuk-body", data-test-id="no-services-content">{{ 'pages.deleteAccount.paragraph4a' | translate }}</p>
+  {% endif %}
+  <p class="govuk-body">{{ 'pages.deleteAccount.paragraph5' | translate }}</p>
 
 {{ govukInsetText({
   text: 'pages.deleteAccount.details' | translate

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -147,9 +148,9 @@ describe("Integration:: delete account", () => {
       .get(PATH_DATA.DELETE_ACCOUNT.url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#no-services-content").text()).to.not.be.empty;
-        expect($("#govuk-email-subscription-info").text()).to.be.empty;
-        expect($("#service-list-item").text()).to.be.empty;
+        expect($(testComponent('no-services-content')).text()).to.not.be.empty;
+        expect($(testComponent('govuk-email-subscription-info')).text()).to.be.empty;
+        expect($(testComponent('service-list-item')).text()).to.be.empty;
       })
       .expect(200, done);
   });
@@ -161,8 +162,8 @@ describe("Integration:: delete account", () => {
       .get(PATH_DATA.DELETE_ACCOUNT.url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#govuk-email-subscription-info").text()).to.not.be.empty;
-        expect($("#service-list-item").text()).to.not.be.empty;
+        expect($(testComponent('govuk-email-subscription-info')).text()).to.not.be.empty;
+        expect($(testComponent('service-list-item')).text()).to.not.be.empty;
       })
       .expect(200, done);
   });
@@ -174,8 +175,8 @@ describe("Integration:: delete account", () => {
       .get(PATH_DATA.DELETE_ACCOUNT.url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#service-list-item").text()).to.not.be.empty;
-        expect($("#govuk-email-subscription-info").text()).to.be.empty;
+        expect($(testComponent('service-list-item')).text()).to.not.be.empty;
+        expect($(testComponent('govuk-email-subscription-info')).text()).to.be.empty;
       })
       .expect(200, done);
   });

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -116,7 +117,7 @@ describe("Integration::enter password", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains("Enter your password");
+        expect($(testComponent('password-error')).text()).to.contains("Enter your password");
       })
       .expect(400, done);
   });
@@ -136,7 +137,7 @@ describe("Integration::enter password", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
+        expect($(testComponent('password-error')).text()).to.contains(
           "Enter the correct password"
         );
       })

--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -42,6 +42,7 @@
 {% 
 set mfaSummaryList = {
   classes:"govuk-summary-list--wide-key",
+  attributes: {"data-test-id": "mfa-summary-list"},
   rows: [{
     key: {
       text: 'pages.manageYourAccount.mfaSection.summaryList.phoneNumber.title' | translate | replace("[phoneNumber]", phoneNumber)
@@ -49,6 +50,7 @@ set mfaSummaryList = {
     actions: {
       items: [
         {
+          attributes: {"data-test-id": "change-phone-number"},
           href: "/enter-password?type=changePhoneNumber",
           text: 'general.change' | translate,
           visuallyHiddenText: 'pages.manageYourAccount.mfaSection.summaryList.phoneNumber.hiddenText' | translate

--- a/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
+++ b/src/components/manage-your-account/tests/manage-your-account-integration.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
 import { sinon, expect } from "../../../../test/utils/test-utils";
+import { testComponent } from "../../../../test/utils/helpers";
 import * as cheerio from "cheerio";
 import * as nock from "nock";
 import decache from "decache";
@@ -39,7 +40,7 @@ describe("Integration:: manage your account", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($(".govuk-summary-list").text()).to.contains(
+        expect($(testComponent('mfa-summary-list')).text()).to.contains(
           TEST_USER_PHONE_NUMBER.slice(-4)
         );
       });
@@ -62,7 +63,7 @@ describe("Integration:: manage your account", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($(".govuk-summary-list").text()).to.not.contains("phoneNumber");
+        expect($(testComponent('change-phone-number')).length).to.equal(0);
       });
   });
 });

--- a/src/components/your-services/tests/your-services-integration.test.ts
+++ b/src/components/your-services/tests/your-services-integration.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest";
 import { describe } from "mocha";
+import { testComponent } from "../../../../test/utils/helpers";
 import { expect, sinon } from "../../../../test/utils/test-utils";
 import * as cheerio from "cheerio";
 import * as nock from "nock";
@@ -32,7 +33,7 @@ describe("Integration:: your services", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($("[data-test-id='empty-state']").length).to.not.equal(0);
+        expect($(testComponent('empty-state')).length).to.not.equal(0);
       });
   });
 
@@ -43,8 +44,8 @@ describe("Integration:: your services", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($("h2[data-test-id='accounts-heading']").length).to.equal(0);
-        expect($("h2[data-test-id='account-card-heading']").length).to.not.equal(0);
+        expect($(`h2${testComponent('accounts-heading')}`).length).to.equal(0);
+        expect($(`h2${testComponent('account-card-heading')}`).length).to.not.equal(0);
       });
   });
 
@@ -55,8 +56,8 @@ describe("Integration:: your services", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($("h2[data-test-id='services-heading']").length).to.equal(0);
-        expect($("h2[data-test-id='service-card-heading']").length).to.not.equal(0);
+        expect($(`h2${testComponent('services-heading')}`).length).to.equal(0);
+        expect($(`h2${testComponent('service-card-heading')}`).length).to.not.equal(0);
       });
   });
 
@@ -68,10 +69,10 @@ describe("Integration:: your services", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($("h3[data-test-id='account-card-heading']").length).to.not.equal(0);
-        expect($("h3[data-test-id='service-card-heading']").length).to.not.equal(0);
-        expect($("h2[data-test-id='services-heading']").length).to.not.equal(0);
-        expect($("h2[data-test-id='accounts-heading']").length).to.not.equal(0);
+        expect($(`h3${testComponent('account-card-heading')}`).length).to.not.equal(0);
+        expect($(`h3${testComponent('service-card-heading')}`).length).to.not.equal(0);
+        expect($(`h2${testComponent('services-heading')}`).length).to.not.equal(0);
+        expect($(`h2${testComponent('accounts-heading')}`).length).to.not.equal(0);
       });
   });
 });

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,0 +1,3 @@
+export function testComponent(componentId: string): string {
+  return `[data-test-id='${componentId}']`;
+}


### PR DESCRIPTION
Update integration tests to use data attribute selectors instead of IDs. 
Remove string checking unless it's relevant to the test (for instance I've left them on the tests dedicated to checking that the specific error messages displayed are correct in different circumstances)

Nothing should change and all the tests should still pass.

https://govukverify.atlassian.net/browse/GUA-760