### PR TITLE
GUA-848: update hint text on Enter new password

### DIFF
--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -16,38 +16,33 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
-    <p class="govuk-body">{{'pages.changePassword.password.paragraph1' | translate}}</p>
-    <ul class="govuk-list govuk-list--bullet">
-     <li>{{ 'pages.changePassword.password.bulletPoint1' | translate}}</li>
-     <li>{{ 'pages.changePassword.password.bulletPoint2' | translate}}</li>
-    </ul>
-
-     <p class="govuk-body">{{'pages.changePassword.password.paragraph2' | translate}}</p>
-
-    {{ govukInputWithShowPassword(
-        'pages.changePassword.password.label'  | translate,
-        "password",
-        errors,
-        {
+    {{ govukInputWithShowPassword({
+        label: 'pages.changePassword.password.label'  | translate,
+        id: "password",
+        errors: errors,
+        hint: 'pages.changePassword.password.hint'  | translate,
+        showSettings: {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate 
+        }
+    })}}
+    {{ govukInputWithShowPassword({
+        label: 'pages.changePassword.confirmPassword.label' | translate,
+        id: "confirm-password",
+        errors: errors,
+        showSettings: {
             show: 'general.showPassword.show' | translate,
             hide: 'general.showPassword.hide' | translate,
             showFullText: 'general.showPassword.showFullText' | translate,
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }) }}
-    {{ govukInputWithShowPassword(
-        'pages.changePassword.confirmPassword.label' | translate,
-        "confirm-password",
-        errors,
-        {
-            show: 'general.showPassword.show' | translate,
-            hide: 'general.showPassword.hide' | translate,
-            showFullText: 'general.showPassword.showFullText' | translate,
-            hideFullText: 'general.showPassword.hideFullText' | translate,
-            announceShown: 'general.showPassword.announceShown' | translate,
-            announceHidden: 'general.showPassword.announceHidden' | translate
-        }) }}
+        }
+    })}}
 
 {{ govukDetails({
   summaryText: 'pages.changePassword.securePasswordDetails.summary' | translate,

--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -1,20 +1,23 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro govukInputWithShowPassword(label, id, errors, showSettings) %}
-    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
+{% macro govukInputWithShowPassword(settings) %}
+    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ settings.showSettings.show }}" data-hide-text="{{ settings.showSettings.hide }}" data-show-full-text="{{ settings.showSettings.showFullText }}" data-hide-full-text="{{ settings.showSettings.hideFullText }}" data-announce-show="{{ settings.showSettings.announceShown }}" data-announce-hide="{{ settings.showSettings.announceHidden }}">
         {{ govukInput({
             label: {
-                text: label
+                text: settings.label
             },
             classes: "govuk-!-width-two-thirds govuk-password-input",
-            id: id,
-            name: id,
+            id: settings.id,
+            name: settings.id,
             type: "password",
             spellcheck: false,
+            hint: {
+                text: settings.hint
+            } if settings.hint,
             errorMessage: {
-                text: errors[id].text,
-                attributes: { "data-test-id": id + "-error"}
-            } if (errors[id])})
+                text: settings.errors[settings.id].text,
+                attributes: { "data-test-id": settings.id + "-error"}
+            } if (settings.errors[settings.id])})
         }}
     </div>
 {% endmacro %}

--- a/src/components/enter-password/_change-email.njk
+++ b/src/components/enter-password/_change-email.njk
@@ -7,18 +7,19 @@
 
     <p class="govuk-body">{{'pages.enterPassword.changeEmail.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword(
-        'pages.enterPassword.password.label' | translate,
-        "password",
-        errors,
-        {
+    {{ govukInputWithShowPassword({
+        label: 'pages.enterPassword.password.label' | translate,
+        id: "password",
+        errors: errors,
+        showSettings: {
             show: 'general.showPassword.show' | translate,
             hide: 'general.showPassword.hide' | translate,
             showFullText: 'general.showPassword.showFullText' | translate,
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }) }}
+        }
+    })}}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/_change-password.njk
+++ b/src/components/enter-password/_change-password.njk
@@ -7,18 +7,19 @@
 
     <p class="govuk-body">{{'pages.enterPassword.changePassword.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword(
-        'pages.enterPassword.password.label' | translate,
-        "password",
-        errors,
-        {
+    {{ govukInputWithShowPassword({
+        label: 'pages.enterPassword.password.label' | translate,
+        id: "password",
+        errors: errors,
+        showSettings: {
             show: 'general.showPassword.show' | translate,
             hide: 'general.showPassword.hide' | translate,
             showFullText: 'general.showPassword.showFullText' | translate,
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }) }}
+        }
+    })}}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/_change-phone-number.njk
+++ b/src/components/enter-password/_change-phone-number.njk
@@ -7,18 +7,19 @@
 
     <p class="govuk-body">{{'pages.enterPassword.changePhoneNumber.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword(
-        'pages.enterPassword.password.label' | translate,
-        "password",
-        errors,
-        {
+    {{ govukInputWithShowPassword({
+        label: 'pages.enterPassword.password.label' | translate,
+        id: "password",
+        errors: errors,
+        showSettings: {
             show: 'general.showPassword.show' | translate,
             hide: 'general.showPassword.hide' | translate,
             showFullText: 'general.showPassword.showFullText' | translate,
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }) }}
+        }
+    }) }}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/_delete-account.njk
+++ b/src/components/enter-password/_delete-account.njk
@@ -7,18 +7,19 @@
 
     <p class="govuk-body">{{'pages.enterPassword.deleteAccount.paragraph' | translate}}</p>
 
-    {{ govukInputWithShowPassword(
-        'pages.enterPassword.password.label' | translate,
-        "password",
-        errors,
-        {
+    {{ govukInputWithShowPassword({
+        label: 'pages.enterPassword.password.label' | translate,
+        id: "password",
+        errors: errors,
+        showSettings: {
             show: 'general.showPassword.show' | translate,
             hide: 'general.showPassword.hide' | translate,
             showFullText: 'general.showPassword.showFullText' | translate,
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }) }}
+        }
+    }) }}
 
     {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -563,11 +563,8 @@
       "title": "Rhowch eich cyfrinair newydd",
       "header": "Rhowch eich cyfrinair newydd",
       "password": {
+        "hint": "Mae'n rhaid iddo fod yn o leiaf 8 nod o hyd a rhaid cynnwys llythrennau a rhifau. Peidiwch defnyddio cyfrinair cyffredin iawn, fel 'password' neu ddilyniant o rifau.",
         "label": "Rhowch gyfrinair newydd",
-        "paragraph1": "Mae’n rhaid i’ch cyfrinair:",
-        "bulletPoint1": "fod yn o leiaf 8 nod o hyd",
-        "bulletPoint2": "cynnwys llythrennau a rhifau",
-        "paragraph2": "Peidiwch defnyddio cyfrinair cyffredin iawn, fel ‘password’ neu ddilyniant o rifau.",
         "validationError": {
           "required": "Rhowch eich cyfrinair newydd",
           "maxLength": "Mae’n rhaid i’ch cyfrinair fod yn llai na 256 nod",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -563,11 +563,8 @@
       "title": "Enter your new password",
       "header": "Enter your new password",
       "password": {
+        "hint": "Your password must be at least 8 characters and must include letters and numbers. Do not use a very common password, such as ‘password’ or a sequence of numbers.",
         "label": "Enter a new password",
-        "paragraph1": "Your password must:",
-        "bulletPoint1": "be at least 8 characters long",
-        "bulletPoint2": "include letters and numbers",
-        "paragraph2": "Do not use a very common password, such as ‘password’ or a sequence of numbers.",
         "validationError": {
           "required": "Enter your new password",
           "maxLength": "Your password must be less than 256 characters",


### PR DESCRIPTION
## Proposed changes

Tweak content on the "Enter your new password" screen to be more in line with the changes auth have implemented. 
The content is more or less the same as before, except now it is delivered as hint text before the input field.

Change the way the ShowPassword component works so that it accepts named parameters instead of nameless ones, for improved readability.

https://govukverify.atlassian.net/browse/GUA-848


## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


### Other considerations
- [ ] Demo to a BA, TA, and the team.
- [ ] Recorded demo shared on [#govuk-accounts-tech](https://gds.slack.com/archives/C011Y5SAY3U)
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
