### PR TITLE
[DO NOT MERGE] AUT-1365: Update content on timeout screen

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -111,7 +111,7 @@
       "header": "Rydych wedi cael eich allgofnodi",
       "content": {
         "paragraph1": "Gallai hyn fod oherwydd:",
-        "listItem1": "nid ydych wedi defnyddio eich GOV.UK One Login am fwy na 2 awr",
+        "listItem1": "heb ddefnyddio eich GOV.UK One Login am fwy nag awr",
         "listItem2": "rydych wedi allgofnodi o'ch GOV.UK One Login tra yn defnyddio gwasanaeth arall",
         "paragraph2": "Rydym wedi eich allgofnodi i gadw eich GOV.UK One Login a'ch gwybodaeth yn ddiogel.",
         "signInButtonText": "Mewngofnodi i GOV.UK One Login",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -111,7 +111,7 @@
       "header": "You’ve been signed out",
       "content": {
         "paragraph1": "This could be because you:",
-        "listItem1": "have not used your GOV.UK One Login for more than 2 hours",
+        "listItem1": "have not used your GOV.UK One Login for more than an hour",
         "listItem2": "signed out of your GOV.UK One Login while using another service",
         "paragraph2": "We signed you out to keep your GOV.UK One Login and your information secure.",
         "signInButtonText": "Sign in to GOV.UK One Login",


### PR DESCRIPTION
Session timeout is changing from 2 hours to one hour. This is to due a decision made by One Login off the back of some incidents. 
This updates the content on the timeout screen to display the updated time of 1 hour inactivity timeout instead of 2.

Additional information and screenshots [on the ticket](https://govukverify.atlassian.net/browse/AUT-1365). 