### PR TITLE
GUA-864 autoscale all environments except dev

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -105,7 +105,6 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
-  IsProduction: !Equals [!Ref Environment, production]
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -1020,7 +1019,7 @@ Resources:
   #
 
   ECSAutoScalingTarget:
-    Condition: IsProduction
+    Condition: IsNotDevelopment
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: !Ref ECSClusterMaxCapacity
@@ -1035,7 +1034,7 @@ Resources:
       ServiceNamespace: ecs
 
   ECSAutoScalingPolicyMemory:
-    Condition: IsProduction
+    Condition: IsNotDevelopment
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: !Sub "${AWS::StackName}-ECSAutoScalingPolicyMemory"
@@ -1054,7 +1053,7 @@ Resources:
     DependsOn: ECSAutoScalingTarget
 
   ECSAutoScalingPolicyCPU:
-    Condition: IsProduction
+    Condition: IsNotDevelopment
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: !Sub "${AWS::StackName}-ECSAutoScalingPolicyCPU"


### PR DESCRIPTION
### What changed
Switch conditionals on autoscaling infrastructure from IsProduction to IsNotDevelopment. THus enabling autoscaling in build, staging and integration. 
Remove IsProduction parameter as nolonger needed. 

### Why did it change
So performance tests can get realistic production-like behaviour in the test environments. 

### Issue tracking
[GUA-864]

[GUA-864]: https://govukverify.atlassian.net/browse/GUA-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ