### PR TITLE
BAU: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/gov-uk-accounts-developers @alphagov/gov-uk-accounts-bravo
+* @alphagov/gov-uk-accounts-developers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/gov-uk-accounts-developers
+* @alphagov/one-login-home-developers


### PR DESCRIPTION
Remove the Bravo team as they're no longer actively working on this app, and rename our team to reflect the [new URL](https://github.com/orgs/alphagov/teams/one-login-home-developers)