### PR TITLE
OLH-890 : Refactor the way Deletion happens for publishing service

### DIFF
--- a/src/components/delete-account/tests/delete-account-service.test.ts
+++ b/src/components/delete-account/tests/delete-account-service.test.ts
@@ -4,16 +4,14 @@ import { SnsService } from "../../../utils/types";
 import { sinon } from "../../../../test/utils/test-utils";
 import { http } from "../../../utils/http";
 
-import {
-  deleteAccountService,
-} from "../delete-account-service";
+import { deleteAccountService } from "../delete-account-service";
 
 describe("deleteAccountService", () => {
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    process.env.DELETE_TOPIC_ARN = "UserAccountDeletionEnv"
+    process.env.DELETE_TOPIC_ARN = "UserAccountDeletionEnv";
   });
 
   afterEach(() => {
@@ -22,24 +20,35 @@ describe("deleteAccountService", () => {
   });
 
   describe("deleteServiceData", () => {
-    const expected_message = JSON.stringify({ "user_id": "abc" })
+    const expected_message = JSON.stringify({
+      user_id: "abc",
+      public_subject_id: "def",
+    });
 
     it("fills the topic ARN from config if not provided", async () => {
-      const fakeSnsService: SnsService = { publish: sandbox.fake() };  
-      await deleteAccountService(http, fakeSnsService).deleteServiceData("abc")
+      const fakeSnsService: SnsService = { publish: sandbox.fake() };
+      await deleteAccountService(http, fakeSnsService).publishToDeleteTopic(
+        "abc",
+        "def"
+      );
       expect(fakeSnsService.publish).to.have.been.calledOnceWith(
         "UserAccountDeletionEnv",
         expected_message
       );
-    })
+    });
 
     it("calls snsService.publish with a topic ARN and message JSON", async () => {
       const fakeSnsService: SnsService = { publish: sandbox.fake() };
-      await deleteAccountService(http, fakeSnsService).deleteServiceData("abc", "UserAccountDeletion")
+      await deleteAccountService(http, fakeSnsService).publishToDeleteTopic(
+        "abc",
+        "def",
+        undefined,
+        "UserAccountDeletion"
+      );
       expect(fakeSnsService.publish).to.have.been.calledOnceWith(
         "UserAccountDeletion",
         expected_message
       );
-    })
-  })
-})
+    });
+  });
+});

--- a/src/components/delete-account/types.ts
+++ b/src/components/delete-account/types.ts
@@ -5,9 +5,11 @@ export interface DeleteAccountServiceInterface {
     sourceIp: string,
     sessionId: string,
     persistentSessionId: string
-  ) => Promise<void>;
-  deleteServiceData: (
+  ) => Promise<boolean>;
+  publishToDeleteTopic: (
     user_id: string,
-    topic_arn?: string,
+    public_subject_id: string,
+    legacy_subject_id?: string,
+    topic_arn?: string
   ) => Promise<void>;
 }


### PR DESCRIPTION
## Proposed changes
Update AM to send the public subject id on the SNS topic . Which will be then consumed by the delete-email-subscriptions lambda on the backend .

### What changed

Remove the call to the publishing API from the delete controller 

### Why did it change

The backend changes to add a new lambda went live a while back and this change is to make sure the front-end is using the backend lambda to delete the email subscriptions instead of calling the publishing API directly . 


