### PR TITLE
OLH-869: Change show password component hidden labels on the "Enter your new password" page

### DIFF
--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -37,10 +37,10 @@
         showSettings: {
             show: 'general.showPassword.show' | translate,
             hide: 'general.showPassword.hide' | translate,
-            showFullText: 'general.showPassword.showFullText' | translate,
-            hideFullText: 'general.showPassword.hideFullText' | translate,
-            announceShown: 'general.showPassword.announceShown' | translate,
-            announceHidden: 'general.showPassword.announceHidden' | translate
+            showFullText: 'pages.changePassword.showRetypedPassword.showFullText' | translate,
+            hideFullText: 'pages.changePassword.showRetypedPassword.hideFullText' | translate,
+            announceShown: 'pages.changePassword.showRetypedPassword.announceShown' | translate,
+            announceHidden: 'pages.changePassword.showRetypedPassword.announceHidden' | translate
         }
     })}}
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -305,6 +305,12 @@
     "changePassword": {
       "title": "Rhowch eich cyfrinair newydd",
       "header": "Rhowch eich cyfrinair newydd",
+      "showRetypedPassword": {
+        "showFullText": "Dangos cyfrinair wedi'i aildeipio",
+        "hideFullText": "Cuddio cyfrinair wedi'i aildeipio",
+        "announceShown": "Mae eich cyfrinair wedi'i aildeipio wedi cael ei ddangos",
+        "announceHidden": "Mae eich cyfrinair wedi'i aildeipio wedi cael ei guddio"
+      },
       "password": {
         "hint": "Mae'n rhaid iddo fod yn o leiaf 8 nod o hyd a rhaid cynnwys llythrennau a rhifau. Peidiwch defnyddio cyfrinair cyffredin iawn, fel 'password' neu ddilyniant o rifau.",
         "label": "Rhowch gyfrinair newydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -305,6 +305,12 @@
     "changePassword": {
       "title": "Enter your new password",
       "header": "Enter your new password",
+      "showRetypedPassword": {
+        "showFullText": "Show retyped password",
+        "hideFullText": "Hide retyped password",
+        "announceShown": "Your retyped password is shown",
+        "announceHidden": "Your retyped password is hidden"
+      },
       "password": {
         "hint": "Your password must be at least 8 characters and must include letters and numbers. Do not use a very common password, such as ‘password’ or a sequence of numbers.",
         "label": "Enter a new password",


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[ATB-XXXX] PR Title` -->

### What changed

Add distinct programmatic labels for the Show Password component on the second password field on the "Enter your new password" page.

The first password component is still using the default labels while the Show Password component associated with the "confirm password" field is using different labels/hidden text to reflect that this is a retyped password.
No visible change will occur as a result of this update.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

This is so that screen reader users can more clearly discern which of the Show/Hide buttons is associated with each password field.

Some context for this update https://github.com/alphagov/govuk-design-system/issues/2795 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- List any related PRs -->
- [OLH-869](https://govukverify.atlassian.net/browse/OLH-869)


[OLH-869]: https://govukverify.atlassian.net/browse/OLH-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ