### PR TITLE
OLH-932: Update Apprenticeship service URL

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -231,7 +231,7 @@
             },
             {
               "text": "Rheoli prentisiaethau",
-              "href": "https://accounts.manage-apprenticeships.service.gov.uk/service/index"
+              "href": "https://accounts.manage-apprenticeships.service.gov.uk/service"
             }
           ]
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -497,7 +497,7 @@
         "link_href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
       },
       "VsAkrtMBzAosSveAv4xsuUDyiSs": {
-        "header":"Sign your mortgage deed",
+        "header": "Sign your mortgage deed",
         "link_text": "Sign your mortgage deed",
         "link_href": "https://sign-your-mortgage-deed.landregistry.gov.uk/interceptor"
       },
@@ -505,7 +505,7 @@
         "header": "Manage apprenticeships",
         "description": "Manage your apprentices, training providers, recruitment and funding.",
         "link_text": "Go to your apprenticeship service account",
-        "link_href": "https://accounts.manage-apprenticeships.service.gov.uk/service/index"
+        "link_href": "https://accounts.manage-apprenticeships.service.gov.uk/service"
       }
     },
     "integration": {
@@ -695,7 +695,7 @@
         "link_href": "https://www.gov.uk/request-copy-criminal-record"
       },
       "vehicleOperatorLicense": {
-        "header":"Apply for a vehicle operator licence",
+        "header": "Apply for a vehicle operator licence",
         "link_text": "Apply for a vehicle operator licence",
         "link_href": "https://www.gov.uk/apply-vehicle-operator-licence"
       },


### PR DESCRIPTION
## Proposed changes

### What changed

Update the URL shown in service cards for the apprenticeships service

### Why did it change

The previous URL was sending users to the service start page in production only, which wasn't signing users in by default. This new URL will do that and give a seamless experience for our users

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
[Onboarding ticket](https://govukverify.atlassian.net/browse/OLH-932)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
