### PR TITLE
Update API_BASE_URL to use the OIDC stub in Dev and Build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -461,7 +461,11 @@ Resources:
               Value: !Sub "${Environment}"
             - Name: "API_BASE_URL"
               Value:
+                !If [
+                  UseStubServices,
+                  !Sub "https://{{resolve:ssm:/${StubsStackName}/Stub/OIDC}}",
                 !FindInMap [EnvironmentVariables, !Ref Environment, APIBASEURL]
+                ]
             - Name: "AM_API_BASE_URL"
               Value:
                 !If [


### PR DESCRIPTION
## What

Use the SSM parameter to connect to the OIDC stub for dev and build .  