### PR TITLE
Update link to Manage apprencetiship in the account blurb

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -215,7 +215,7 @@
             },
             {
               "text": "Rheoli prentisiaethau",
-              "href": "https://accounts.manage-apprenticeships.service.gov.uk/service"
+              "href": "https://www.gov.uk/sign-in-apprenticeship-service-account"
             },
             {
               "text": "Cofrestrfa datganiad caethwasiaeth modern",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -215,7 +215,7 @@
             },
              {
               "text": "Manage apprenticeships",
-              "href": "https://accounts.manage-apprenticeships.service.gov.uk/service"
+              "href": "https://www.gov.uk/sign-in-apprenticeship-service-account"
             },
             {
               "text": "Modern slavery statement registry",


### PR DESCRIPTION


### What changed

The link in the account blurb for Apprenticeship service was pointing to incorrect location.
This link was updated from https://employerprofiles.manage-apprenticeships.service.gov.uk/user/add-user-details?_ga=&_gl=&utm_source=&utm_campaign=&utm_medium=&utm_keywords=&utm_content= to https://www.gov.uk/sign-in-apprenticeship-service-account




