### PR TITLE
OLH-950: Update link to GOV.UK email subscriptions

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -207,7 +207,7 @@
             },
             {
               "text": "Tanysgrifiadau e-byst GOV.UK",
-              "href": "https://www.gov.uk/email/manage"
+              "href": "https://www.gov.uk/email/manage?from=your-services"
             },
             {
               "text": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
@@ -460,7 +460,7 @@
         "header": "Tanysgrifiadau e-byst GOV.UK",
         "description": "Gweld a rheoli’r diweddariadau rydych yn eu cael am dudalennau GOV.UK mae gennych ddiddordeb ynddynt.",
         "link_text": "Ewch i’ch tanysgrifiadau e-byst GOV.UK",
-        "link_href": "https://www.gov.uk/email/manage"
+        "link_href": "https://www.gov.uk/email/manage?from=your-services"
       },
       "ZL0kvRBP5xMy5OwONj8ARLPyuko": {
         "header": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
@@ -512,7 +512,7 @@
         "header": "Tanysgrifiadau e-byst GOV.UK",
         "description": "Gweld a rheoli’r diweddariadau rydych yn eu cael am dudalennau GOV.UK mae gennych ddiddordeb ynddynt.",
         "link_text": "Ewch i’ch tanysgrifiadau e-byst GOV.UK",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.staging.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "JO3ET6EtFN3FzjGC3yRP2qpuoHQ": {
         "header": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
@@ -564,7 +564,7 @@
         "header": "Tanysgrifiadau e-byst GOV.UK",
         "description": "Gweld a rheoli’r diweddariadau rydych yn eu cael am dudalennau GOV.UK mae gennych ddiddordeb ynddynt.",
         "link_text": "Ewch i’ch tanysgrifiadau e-byst GOV.UK",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
@@ -616,7 +616,7 @@
         "header": "Tanysgrifiadau e-byst GOV.UK",
         "description": "Gweld a rheoli’r diweddariadau rydych yn eu cael am dudalennau GOV.UK mae gennych ddiddordeb ynddynt.",
         "link_text": "Ewch i’ch tanysgrifiadau e-byst GOV.UK",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
@@ -668,7 +668,7 @@
         "header": "Tanysgrifiadau e-byst GOV.UK",
         "description": "Gweld a rheoli’r diweddariadau rydych yn eu cael am dudalennau GOV.UK mae gennych ddiddordeb ynddynt.",
         "link_text": "Ewch i’ch tanysgrifiadau e-byst GOV.UK",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
@@ -720,7 +720,7 @@
         "header": "Tanysgrifiadau e-byst GOV.UK",
         "description": "Gweld a rheoli’r diweddariadau rydych yn eu cael am dudalennau GOV.UK mae gennych ddiddordeb ynddynt.",
         "link_text": "Ewch i’ch tanysgrifiadau e-byst GOV.UK",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -207,13 +207,13 @@
             },
             {
               "text": "GOV.UK email subscriptions",
-              "href": "https://www.gov.uk/email/manage"
+              "href": "https://www.gov.uk/email/manage?from=your-services"
             },
             {
               "text": "LITE (Licensing for International Trade and Enterprise)",
               "href": "https://exporter.lite.private-beta.service.trade.gov.uk/"
             },
-             {
+            {
               "text": "Manage apprenticeships",
               "href": "https://www.gov.uk/sign-in-apprenticeship-service-account"
             },
@@ -461,7 +461,7 @@
         "header": "GOV.UK email subscriptions",
         "description": "See and manage the updates you get about GOV.UK pages you’re interested in.",
         "link_text": "Go to your GOV.UK email subscriptions",
-        "link_href": "https://www.gov.uk/email/manage"
+        "link_href": "https://www.gov.uk/email/manage?from=your-services"
       },
       "ZL0kvRBP5xMy5OwONj8ARLPyuko": {
         "header": "LITE (Licensing for International Trade and Enterprise)",
@@ -513,7 +513,7 @@
         "header": "GOV.UK email subscriptions",
         "description": "See and manage the updates you get about GOV.UK pages you’re interested in.",
         "link_text": "Go to your GOV.UK email subscriptions",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.staging.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "JO3ET6EtFN3FzjGC3yRP2qpuoHQ": {
         "header": "LITE (Licensing for International Trade and Enterprise)",
@@ -565,7 +565,7 @@
         "header": "GOV.UK email subscriptions",
         "description": "See and manage the updates you get about GOV.UK pages you’re interested in.",
         "link_text": "Go to your GOV.UK email subscriptions",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Licensing for International Trade and Enterprise)",
@@ -617,7 +617,7 @@
         "header": "GOV.UK email subscriptions",
         "description": "See and manage the updates you get about GOV.UK pages you’re interested in.",
         "link_text": "Go to your GOV.UK email subscriptions",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Licensing for International Trade and Enterprise)",
@@ -669,7 +669,7 @@
         "header": "GOV.UK email subscriptions",
         "description": "See and manage the updates you get about GOV.UK pages you’re interested in.",
         "link_text": "Go to your GOV.UK email subscriptions",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Licensing for International Trade and Enterprise)",
@@ -721,7 +721,7 @@
         "header": "GOV.UK email subscriptions",
         "description": "See and manage the updates you get about GOV.UK pages you’re interested in.",
         "link_text": "Go to your GOV.UK email subscriptions",
-        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage"
+        "link_href": "https://www.integration.publishing.service.gov.uk/email/manage?from=your-services"
       },
       "lite": {
         "header": "LITE (Licensing for International Trade and Enterprise)",


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add a URL parameter to all links to GOV.UK email subscriptions.

Also correct the environments - GOV.UK's integration environment uses our staging one, and their staging uses our integration. 

### Why did it change

The GOV.UK email subscriptions service currently has two ways to authenticate a user. Adding this URL parameter to links from the GOV.UK One Login home allows the email service to know that that user should be authenticated through GOV.UK One Login.

This means the user can skip a step when signing into the email service as it no longer needs to work out which authentication method to use.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done -->
I've run the app locally and checked the URL parameter was present.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
