### PR TITLE
BAU: Group minor and patch upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,18 @@ updates:
         versions: ["17.x", "18.x", "19.x"]
     commit-message:
       prefix: BAU
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: docker
     directory: "/"
     schedule:


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use the new ['groups' feature]([1]) from Dependabot to group together minor and patch updates. I've put the development and production dependencies in separate groups. This means we'll get one PR with all the development updates and a second with all the production ones.

Any library update which is a major change as indicated by semver will still get its own PR.

### Why did it change

This should mean we have fewer PRs from dependabot to manage while still being able to tackle the major version upgrades easily.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review

Github has syntax checking built in for Dependabot config files, so if that's happy this is probably a valid config. Please check against the documentation to be sure though!

[1]: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
