### PR TITLE
BAU: Enable the API Gateway 5XX error alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -464,7 +464,11 @@ Resources:
                 !If [
                   UseStubServices,
                   !Sub "https://{{resolve:ssm:/${StubsStackName}/Stub/OIDC}}",
-                !FindInMap [EnvironmentVariables, !Ref Environment, APIBASEURL]
+                  !FindInMap [
+                    EnvironmentVariables,
+                    !Ref Environment,
+                    APIBASEURL,
+                  ],
                 ]
             - Name: "AM_API_BASE_URL"
               Value:
@@ -1481,7 +1485,7 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGateway5xxStatusAlarm"
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Enable the API Gateway 5XX error alarm

This alarm triggers when more than 1% of responses from API Gateway are a 5XX status code, as long as there have been a minimum of 10 responses in two out of the last 5 minutes.

The most likely reason for this alarm to trigger is the frontend either being down completely or having some other problem that needs attention.

### Why did it change

This closes a gap in our monitoring of the frontend to provide a proactive notification to us if there's a problem.

In its current configuration, this alarm sends a slack message to the `#govuk-accounts-notifications` channel. In the future we should update it to also send alarms in production to `#di-2nd-line`. 

### Related links

This PR partially addresses [risk OLH-900](https://govukverify.atlassian.net/browse/OLH-900)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

We've had this alarm set up for the best part of a year with actions enabled. I've checked the alarm history and I'm confident there haven't been any false positives so it's safe to switch it on.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
