### PR TITLE
BAU: Exclude tests from Sonar analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,9 +5,9 @@ sonar.organization=alphagov
 sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src/
-sonar.tests=test/
+sonar.exclusions=src/**/*.test.ts,src/assets/javascript/*.js
+sonar.tests=test/,src/
+sonar.test.inclusions=**/*.test.ts
 
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-
-sonar.exclusions=src/assets/javascript/all.js


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use Sonar's analysis scope feature[^1] to exclude the test files from the source code analysis, and include them for test code analysis.

### Why did it change

Sonar is currently reporting 28% code coverage from our tests, but mocha reports ~80% live coverage. This is because Sonar is including the `*.test.ts` files as source code, not test code.

### Related links

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review

Check that the latest Sonar run for this branch is happy. We only run coverage tests against the `main` branch, so we'll need to wait until this PR is merged to see if this has helped.

[^1]: https://docs.sonarsource.com/sonarqube/latest/project-administration/analysis-scope/