### PR TITLE
BAU: Use the dev environment for webchat

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,3 +21,4 @@ SUPPORT_ACTIVITY_LOG=1
 ACTIVITY_LOG_STORE_TABLE_NAME=activity_logs
 SUPPORT_TRIAGE_PAGE=1
 SUPPORT_WEBCHAT_DEMO=1
+WEBCHAT_SOURCE_URL=https://dev-chat-loader.smartagent.app/loader/main.js

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -143,6 +143,7 @@ Mappings:
       LOGSLEVEL: "debug"
       SUPPORTTRIAGEPAGE: "1"
       SUPPORTWEBCHATDEMO: "1"
+      WEBCHATSOURCEURL: "https://dev-chat-loader.smartagent.app/loader/main.js"
     build:
       NODEENV: "production"
       APIBASEURL: "https://oidc.build.account.gov.uk"
@@ -159,6 +160,7 @@ Mappings:
       LOGSLEVEL: "debug"
       SUPPORTTRIAGEPAGE: "1"
       SUPPORTWEBCHATDEMO: "1"
+      WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
     staging:
       NODEENV: "production"
       APIBASEURL: "https://oidc.staging.account.gov.uk"
@@ -175,6 +177,7 @@ Mappings:
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "1"
       SUPPORTWEBCHATDEMO: "1"
+      WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
     integration:
       NODEENV: "production"
       APIBASEURL: "https://oidc.integration.account.gov.uk"
@@ -191,6 +194,7 @@ Mappings:
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "0"
       SUPPORTWEBCHATDEMO: "1"
+      WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
     production:
       NODEENV: "production"
       APIBASEURL: "https://oidc.account.gov.uk"
@@ -207,6 +211,7 @@ Mappings:
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "0"
       SUPPORTWEBCHATDEMO: "0"
+      WEBCHATSOURCEURL: "0"
 
 Resources:
   #
@@ -586,6 +591,13 @@ Resources:
                   EnvironmentVariables,
                   !Ref Environment,
                   SUPPORTWEBCHATDEMO,
+                ]
+            - Name: "WEBCHAT_SOURCE_URL"
+              Value:
+                !FindInMap [
+                  EnvironmentVariables,
+                  !Ref Environment,
+                  WEBCHATSOURCEURL,
                 ]
       Cpu: 1024
       Memory: 2048

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,10 @@ import i18nextMiddleware from "i18next-http-middleware";
 import * as path from "path";
 import { configureNunjucks } from "./config/nunchucks";
 import { i18nextConfigurationOptions } from "./config/i18next";
-import { helmetConfiguration } from "./config/helmet";
+import {
+  helmetConfiguration,
+  webchatHelmetConfiguration,
+} from "./config/helmet";
 import helmet from "helmet";
 import session from "express-session";
 import { setHtmlLangMiddleware } from "./middleware/html-lang-middleware";
@@ -94,7 +97,11 @@ async function createApp(): Promise<express.Application> {
     );
 
   app.use(i18nextMiddleware.handle(i18next));
-  app.use(helmet(helmetConfiguration));
+  if (supportWebchatDemo()) {
+    app.use(helmet(webchatHelmetConfiguration));
+  } else {
+    app.use(helmet(helmetConfiguration));
+  }
 
   const sessionStore = getSessionStore({ session: session });
   app.use(

--- a/src/components/webchat-demo/index.njk
+++ b/src/components/webchat-demo/index.njk
@@ -5,7 +5,7 @@
 {% block pageContent %}
 
 <script id="smartagent" type="module" defer 
-  src="https://uat-chat-loader.smartagent.app/loader/main.js" 
+  src="{{ webchatSource }}" 
   data-company="hgsgds" data-brand="hgsgds">
 </script>
 

--- a/src/components/webchat-demo/webchat-demo-controller.ts
+++ b/src/components/webchat-demo/webchat-demo-controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
+import { getWebchatUrl } from "../../config";
 
 export function webchatGet(req: Request, res: Response): void {
-  const data = {};
+  const data = { webchatSource: getWebchatUrl() };
 
   res.render("webchat-demo/index.njk", data);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,3 +163,12 @@ export function supportTriagePage(): boolean {
 export function supportWebchatDemo(): boolean {
   return process.env.SUPPORT_WEBCHAT_DEMO === "1";
 }
+
+export function getWebchatUrl(): string {
+  const env = getAppEnv();
+  if (env == "local" || env == "dev") {
+    return "https://dev-chat-loader.smartagent.app/loader/main.js";
+  } else {
+    return "https://uat-chat-loader.smartagent.app/loader/main.js";
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -165,10 +165,5 @@ export function supportWebchatDemo(): boolean {
 }
 
 export function getWebchatUrl(): string {
-  const env = getAppEnv();
-  if (env == "local" || env == "dev") {
-    return "https://dev-chat-loader.smartagent.app/loader/main.js";
-  } else {
-    return "https://uat-chat-loader.smartagent.app/loader/main.js";
-  }
+  return process.env.WEBCHAT_SOURCE_URL;
 }

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -5,7 +5,47 @@ export const helmetConfiguration: Parameters<typeof helmet>[0] = {
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      styleSrc: ["'self'"],
+      scriptSrc: [
+        "'self'",
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        (req: Request, res: Response): string =>
+          `'nonce-${res.locals.scriptNonce}'`,
+        "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
+        "https://www.googletagmanager.com",
+        "https://www.google-analytics.com",
+        "https://ssl.google-analytics.com",
+      ],
+      imgSrc: [
+        "'self'",
+        "data:",
+        "https://www.googletagmanager.com",
+        "https://www.google-analytics.com",
+      ],
+      objectSrc: ["'none'"],
+      connectSrc: ["'self'", "https://www.google-analytics.com"],
+      formAction: ["'self'", "https://*.account.gov.uk"],
+    },
+  },
+  dnsPrefetchControl: {
+    allow: false,
+  },
+  frameguard: {
+    action: "deny",
+  },
+  hsts: {
+    maxAge: 31536000, // 1 Year
+    preload: true,
+    includeSubDomains: true,
+  },
+  referrerPolicy: false,
+  permittedCrossDomainPolicies: false,
+};
+
+export const webchatHelmetConfiguration: Parameters<typeof helmet>[0] = {
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", "https://*.smartagent.app", "'unsafe-inline'"],
       scriptSrc: [
         "'self'",
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -16,7 +56,9 @@ export const helmetConfiguration: Parameters<typeof helmet>[0] = {
         "https://www.google-analytics.com",
         "https://ssl.google-analytics.com",
         "https://*.smartagent.app",
+        "'unsafe-inline'",
       ],
+      scriptSrcAttr: ["'self'", "'unsafe-inline'"],
       imgSrc: [
         "'self'",
         "data:",
@@ -30,6 +72,8 @@ export const helmetConfiguration: Parameters<typeof helmet>[0] = {
         "https://*.smartagent.app",
       ],
       formAction: ["'self'", "https://*.account.gov.uk"],
+      mediaSrc: ["'self'", "https://*.s3.eu-west-2.amazonaws.com"],
+      frameSrc: ["'self'", "https://*.smartagent.app"],
     },
   },
   dnsPrefetchControl: {


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use the supplier's dev webchat environment for local testing and in our dev environment. I also had to make some further CSP changes to allow it to inject more scripts and styles. These include the `'unsafe-inline'` directive which I don't want to allow in production as it makes us much more vulnerable to attacks like XSS [^1]. 

We can hopefully work with the supplier to use hashes or nonces to secure the scripts they load for production. In the meantime, I've put the CSP changes for webchat behind the feature flag so we can deploy this change and still use the stricter CSP.

### Why did it change

They've added our dev domain to their allowlist so we can start testing how the webchat will work.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

I've run the app locally, gone to `/webchat-demo` and checked the console for errors.

![image](https://github.com/alphagov/di-account-management-frontend/assets/6362602/3d5bfd69-2741-46e3-bfc8-33d94b82f202)

[^1]: https://content-security-policy.com/unsafe-inline/