### PR TITLE
OLH-1114 Extract fromUrl from request param or session for Contact Centre Page

### DIFF
--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -1,24 +1,48 @@
 import { Request, Response } from "express";
+import pino from "pino";
+import { isValidUrl } from "./../../utils/strings";
+<<<<<<< HEAD
 import {
   supportWebchatContact,
   supportPhoneContact,
   showContactGuidance,
 } from "../../config";
 
+const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
+const logger = pino();
+
 export function contactGet(req: Request, res: Response): void {
   const isAuthenticated = req.session?.user?.isAuthenticated;
   let isLoggedOut = req.cookies?.lo;
+  const fromURL = getFromUrlAndSaveIt(req);
 
   if (typeof(isLoggedOut) === 'string') {
     isLoggedOut = JSON.parse(isLoggedOut)
+  }
+  
+  if (!fromURL) {
+    logger.info(
+      "Request to contact-govuk-one-login page did not contain a valid fromURL in the request or session"
+    );
   }
 
   const data = {
     contactWebchatEnabled: supportWebchatContact(),
     contactPhoneEnabled: supportPhoneContact(),
     showContactGuidance: showContactGuidance(),
-    showSignOut: isAuthenticated && !isLoggedOut
+    showSignOut: isAuthenticated && !isLoggedOut,
+    fromURL
   };
   
   res.render("contact-govuk-one-login/index.njk", data);
 }
+
+const getFromUrlAndSaveIt = (request: Request): string => {
+  const fromURLFromRequest = request.query.fromURL as string;
+  if (isValidUrl(fromURLFromRequest)) {
+    request.session.fromURL = fromURLFromRequest;
+    return fromURLFromRequest;
+  }
+  const fromURLFromSession = request.session.fromURL;
+  return fromURLFromSession;
+};

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import pino from "pino";
-import { isValidUrl } from "./../../utils/strings";
-<<<<<<< HEAD
+import { isSafeString, isValidUrl } from "./../../utils/strings";
 import {
   supportWebchatContact,
   supportPhoneContact,
@@ -16,33 +15,62 @@ export function contactGet(req: Request, res: Response): void {
   let isLoggedOut = req.cookies?.lo;
   const fromURL = getFromUrlAndSaveIt(req);
 
-  if (typeof(isLoggedOut) === 'string') {
-    isLoggedOut = JSON.parse(isLoggedOut)
+  if (typeof isLoggedOut === "string") {
+    isLoggedOut = JSON.parse(isLoggedOut);
   }
-  
+
   if (!fromURL) {
     logger.info(
       "Request to contact-govuk-one-login page did not contain a valid fromURL in the request or session"
     );
   }
 
+  // optional fields from mobile
+  const theme = getValueFromRequestOrSession(req, "theme");
+  const appSessionId = getValueFromRequestOrSession(req, "appSessionId");
+  const appErrorCode = getValueFromRequestOrSession(req, "appErrorCode");
+
   const data = {
     contactWebchatEnabled: supportWebchatContact(),
     contactPhoneEnabled: supportPhoneContact(),
     showContactGuidance: showContactGuidance(),
     showSignOut: isAuthenticated && !isLoggedOut,
-    fromURL
+    fromURL,
+    appSessionId,
+    appErrorCode,
+    theme,
   };
-  
-  res.render("contact-govuk-one-login/index.njk", data);
+
+  res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);
 }
 
 const getFromUrlAndSaveIt = (request: Request): string => {
   const fromURLFromRequest = request.query.fromURL as string;
-  if (isValidUrl(fromURLFromRequest)) {
+  if (fromURLFromRequest && isValidUrl(fromURLFromRequest)) {
     request.session.fromURL = fromURLFromRequest;
     return fromURLFromRequest;
+  } else if (fromURLFromRequest) {
+    logger.error(
+      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+    );
   }
   const fromURLFromSession = request.session.fromURL;
   return fromURLFromSession;
+};
+
+const getValueFromRequestOrSession = (
+  request: Request,
+  propertyName: string
+): string => {
+  const valueFromRequest = request.query[`${propertyName}`] as string;
+  if (valueFromRequest && isSafeString(valueFromRequest)) {
+    request.session[`${propertyName}`] = valueFromRequest;
+    return valueFromRequest;
+  } else if (valueFromRequest) {
+    logger.error(
+      `${propertyName} in request query for contact-govuk-one-login page did not pass validation`
+    );
+  }
+  const valueFromSession = request.session[`${propertyName}`];
+  return valueFromSession;
 };

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -19,7 +19,11 @@ describe("Contact GOV.UK One Login controller", () => {
       body: {},
       cookies: { lng: "en" },
       query: {},
-      session: {},
+      session: {
+        user: {
+          isAuthenticated: true,
+        },
+      },
       log: logger,
     };
     res = {
@@ -30,6 +34,9 @@ describe("Contact GOV.UK One Login controller", () => {
     };
 
     process.env.SUPPORT_TRIAGE_PAGE = "1";
+    process.env.SUPPORT_PHONE_CONTACT = "1";
+    process.env.SHOW_CONTACT_GUIDANCE = "1";
+    process.env.SUPPORT_WEBCHAT_CONTACT = "1";
   });
 
   afterEach(() => {
@@ -42,17 +49,116 @@ describe("Contact GOV.UK One Login controller", () => {
       const validUrl = "https://home.account.gov.uk/security";
       req.query.fromURL = validUrl;
       contactGet(req as Request, res as Response);
+      // query data should be passed to the page render
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
         fromURL: validUrl,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+      });
+      // query data should be saved into session
+      expect(req.session.fromURL).to.equal(validUrl);
+    });
+
+    it("should render contact centre triage page with fromURL from session and signedOut = false ", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      req.session = {
+        fromURL: validUrl,
+        user: {
+          isAuthenticated: false,
+        },
+      };
+      contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: false,
+        fromURL: validUrl,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
       });
     });
 
-    it("should render contact centre triage page when session contains fromURL", () => {
+    it("should render contact centre triage page with additional fields from the mobile app", () => {
       const validUrl = "https://home.account.gov.uk/security";
-      req.session = { fromURL: validUrl };
+      const appSessionId = "123456789";
+      const appErrorCode = "ERRORCODE123";
+      const theme = "WaveyTheme";
+      req.query.fromURL = validUrl;
+      req.query.appSessionId = appSessionId;
+      req.query.appErrorCode = appErrorCode;
+      req.query.theme = theme;
+      contactGet(req as Request, res as Response);
+      // query data should be passed to the page render
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+        appSessionId,
+        appErrorCode,
+        theme,
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
+      });
+      // query data should be saved into session
+      expect(req.session.fromURL).to.equal(validUrl);
+      expect(req.session.appSessionId).to.equal(appSessionId);
+      expect(req.session.appErrorCode).to.equal(appErrorCode);
+      expect(req.session.theme).to.equal(theme);
+    });
+
+    it("should render contact centre triage page with invalid fields from the mobile app", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      const appSessionId =
+        "123456789123456789123456789123456789123456789123456789123456789123456789123456789"; // too long
+      const appErrorCode = ";;***;;"; // unsafe characters
+      req.query.fromURL = validUrl;
+      req.query.appSessionId = appSessionId;
+      req.query.appErrorCode = appErrorCode;
+      contactGet(req as Request, res as Response);
+      // invalid query data not should be passed to the page render
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
+      });
+      // invalid query data should not be saved into session
+      expect(req.session.fromURL).to.equal(validUrl);
+      expect(req.session.appSessionId).to.be.undefined;
+      expect(req.session.appErrorCode).to.be.undefined;
+      expect(req.session.theme).to.be.undefined;
+    });
+
+    it("should render contact centre triage page with additional fields from the mobile app from session", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      const appSessionId = "123456789";
+      const appErrorCode = "ERRORCODE123";
+      const theme = "WaveyTheme";
+      req.session.fromURL = validUrl;
+      req.session.appSessionId = appSessionId;
+      req.session.appErrorCode = appErrorCode;
+      req.session.theme = theme;
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: validUrl,
+        appSessionId,
+        appErrorCode,
+        theme,
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
       });
     });
 
@@ -62,6 +168,13 @@ describe("Contact GOV.UK One Login controller", () => {
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: undefined,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
       });
     });
 
@@ -69,6 +182,13 @@ describe("Contact GOV.UK One Login controller", () => {
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: undefined,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
       });
     });
   });

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
 import { describe } from "mocha";
 import { Request, Response } from "express";
-
 import { sinon } from "../../../../test/utils/test-utils";
-
 import { contactGet } from "../contact-govuk-one-login-controller";
+import { logger } from "../../../utils/logger";
+
+const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 
 describe("Contact GOV.UK One Login controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -17,6 +18,9 @@ describe("Contact GOV.UK One Login controller", () => {
     req = {
       body: {},
       cookies: { lng: "en" },
+      query: {},
+      session: {},
+      log: logger,
     };
     res = {
       render: sandbox.fake(),
@@ -35,11 +39,37 @@ describe("Contact GOV.UK One Login controller", () => {
 
   describe("contactGet", () => {
     it("should render contact centre triage page", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      req.query.fromURL = validUrl;
       contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+      });
+    });
 
-      expect(res.render).to.have.calledWith(
-        "contact-govuk-one-login/index.njk"
-      );
+    it("should render contact centre triage page when session contains fromURL", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      req.session = { fromURL: validUrl };
+      contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+      });
+    });
+
+    it("should render centre triage page when invalid fromURL is present", () => {
+      const invalidUrl = "DROP * FROM *;";
+      req.query.fromURL = invalidUrl;
+      contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: undefined,
+      });
+    });
+
+    it("should render centre triage page when no fromURL is present", () => {
+      contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: undefined,
+      });
     });
   });
 });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -3,6 +3,9 @@ import { randomBytes } from "crypto";
 const urlRegex = new RegExp(
   "^(http(s)?://)?(www.)?[-a-zA-Z0-9@:%.+~#=]{2,256}\\.[a-z]{2,6}([-a-zA-Z0-9@:%_+.~#?&//=]*)$"
 );
+const lowerAndUpperCaseLettersAndNumbersMax50 = new RegExp(
+  "^[a-zA-Z0-9_-]{1,50}$"
+);
 
 export function containsNumber(value: string): boolean {
   return value ? /\d/.test(value) : false;
@@ -24,4 +27,8 @@ export function generateNonce(): string {
 
 export function isValidUrl(url: string): boolean {
   return urlRegex.test(url);
+}
+
+export function isSafeString(url: string): boolean {
+  return lowerAndUpperCaseLettersAndNumbersMax50.test(url);
 }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from "crypto";
 
+const urlRegex = new RegExp(
+  "^(http(s)?://)?(www.)?[-a-zA-Z0-9@:%.+~#=]{2,256}\\.[a-z]{2,6}([-a-zA-Z0-9@:%_+.~#?&//=]*)$"
+);
+
 export function containsNumber(value: string): boolean {
   return value ? /\d/.test(value) : false;
 }
@@ -16,4 +20,8 @@ export function redactPhoneNumber(value: string): string | undefined {
 
 export function generateNonce(): string {
   return randomBytes(16).toString("hex");
+}
+
+export function isValidUrl(url: string): boolean {
+  return urlRegex.test(url);
 }

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -3,6 +3,7 @@ import { describe } from "mocha";
 import {
   containsNumber,
   containsNumbersOnly,
+  isSafeString,
   isValidUrl,
   redactPhoneNumber,
 } from "../../../src/utils/strings";
@@ -68,8 +69,9 @@ describe("string-helpers", () => {
       expect(isValidUrl("home.account.gov.uk")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk/security")).to.be.true;
-      expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo")).to.be.true;
-    })
+      expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo"))
+        .to.be.true;
+    });
 
     it("should return false if url is invalid", () => {
       expect(isValidUrl("")).to.be.false;
@@ -79,5 +81,28 @@ describe("string-helpers", () => {
       expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
     });
 
-  })
+    it("should return true if string is safe is invalid", () => {
+      expect(isValidUrl("")).to.be.false;
+      expect(isValidUrl("1")).to.be.false;
+      expect(isValidUrl("qwerty")).to.be.false;
+      expect(isValidUrl("qwerty.gov.&^")).to.be.false;
+      expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
+    });
+  });
+
+  describe("isSafeString", () => {
+    it("letters numbers hyphens and underscores should be accepted", () => {
+      expect(isSafeString("hEllo-12_3")).to.be.true;
+    });
+
+    it("should return false if contains special characters", () => {
+      expect(isSafeString("hEllo***")).to.be.false;
+    });
+
+    it("should return false if over 50 characters", () => {
+      expect(
+        isSafeString("qqqqqqqqqqaaaaaaaaaahhhhhhhhhhhddddddddddooooooooooojjj")
+      ).to.be.false;
+    });
+  });
 });

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -3,6 +3,7 @@ import { describe } from "mocha";
 import {
   containsNumber,
   containsNumbersOnly,
+  isValidUrl,
   redactPhoneNumber,
 } from "../../../src/utils/strings";
 
@@ -60,4 +61,23 @@ describe("string-helpers", () => {
       expect(redactPhoneNumber("")).to.equal(undefined);
     });
   });
+
+  describe("isValidUrl", () => {
+    it("should return true if valid", () => {
+      expect(isValidUrl("www.home.account.gov.uk")).to.be.true;
+      expect(isValidUrl("home.account.gov.uk")).to.be.true;
+      expect(isValidUrl("https://home.account.gov.uk")).to.be.true;
+      expect(isValidUrl("https://home.account.gov.uk/security")).to.be.true;
+      expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo")).to.be.true;
+    })
+
+    it("should return false if url is invalid", () => {
+      expect(isValidUrl("")).to.be.false;
+      expect(isValidUrl("1")).to.be.false;
+      expect(isValidUrl("qwerty")).to.be.false;
+      expect(isValidUrl("qwerty.gov.&^")).to.be.false;
+      expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
+    });
+
+  })
 });


### PR DESCRIPTION
## Proposed changes
`[OLH-1114] Extract fromUrl from request param or session for Contact Centre Page`

### What changed
Check query param and session for a valil fromUrl. If not present then return an error page and log the error. 

## Checklists

### Environment variables or secrets
- [/] No environment variables or secrets were added or changed

## Testing
Unit tests. 
Deployed to dev and saw page loading in all scenarios. Can't yet test the link to contact form because the link will be created on a different ticket.


[OLH-1114]: https://govukverify.atlassian.net/browse/OLH-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ