### PR TITLE
OLH-1153 append contact centre params from mobile to session data

### DIFF
--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { isValidUrl } from "./../../utils/strings";
+import { isSafeString, isValidUrl } from "./../../utils/strings";
 import pino from "pino";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
@@ -12,18 +12,47 @@ export function contactGet(req: Request, res: Response): void {
       "Request to contact-govuk-one-login page did not contain a valid fromURL in the request or session"
     );
   }
+  // optional fields from mobile
+  const theme = getValueFromRequestOrSession(req, "theme");
+  const appSessionId = getValueFromRequestOrSession(req, "appSessionId");
+  const appErrorCode = getValueFromRequestOrSession(req, "appErrorCode");
+
   const data = {
-    fromURL: fromURL,
+    fromURL,
+    appSessionId,
+    appErrorCode,
+    theme,
   };
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);
 }
 
 const getFromUrlAndSaveIt = (request: Request): string => {
   const fromURLFromRequest = request.query.fromURL as string;
-  if (isValidUrl(fromURLFromRequest)) {
+  if (fromURLFromRequest && isValidUrl(fromURLFromRequest)) {
     request.session.fromURL = fromURLFromRequest;
     return fromURLFromRequest;
+  } else if (fromURLFromRequest) {
+    logger.error(
+      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+    );
   }
   const fromURLFromSession = request.session.fromURL;
   return fromURLFromSession;
+};
+
+const getValueFromRequestOrSession = (
+  request: Request,
+  propertyName: string
+): string => {
+  const valueFromRequest = request.query[`${propertyName}`] as string;
+  if (valueFromRequest && isSafeString(valueFromRequest)) {
+    request.session[`${propertyName}`] = valueFromRequest;
+    return valueFromRequest;
+  } else if (valueFromRequest) {
+    logger.error(
+      `${propertyName} in request query for contact-govuk-one-login page did not pass validation`
+    );
+  }
+  const valueFromSession = request.session[`${propertyName}`];
+  return valueFromSession;
 };

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -42,9 +42,15 @@ describe("Contact GOV.UK One Login controller", () => {
       const validUrl = "https://home.account.gov.uk/security";
       req.query.fromURL = validUrl;
       contactGet(req as Request, res as Response);
+      // query data should be passed to the page render
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: validUrl,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
       });
+      // query data should be saved into session
+      expect(req.session.fromURL).to.equal(validUrl);
     });
 
     it("should render contact centre triage page when session contains fromURL", () => {
@@ -53,6 +59,73 @@ describe("Contact GOV.UK One Login controller", () => {
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: validUrl,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+      });
+    });
+
+    it("should render contact centre triage page with additional fields from the mobile app", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      const appSessionId = "123456789";
+      const appErrorCode = "ERRORCODE123";
+      const theme = "WaveyTheme";
+      req.query.fromURL = validUrl;
+      req.query.appSessionId = appSessionId;
+      req.query.appErrorCode = appErrorCode;
+      req.query.theme = theme;
+      contactGet(req as Request, res as Response);
+      // query data should be passed to the page render
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+        appSessionId,
+        appErrorCode,
+        theme,
+      });
+      // query data should be saved into session
+      expect(req.session.fromURL).to.equal(validUrl);
+      expect(req.session.appSessionId).to.equal(appSessionId);
+      expect(req.session.appErrorCode).to.equal(appErrorCode);
+      expect(req.session.theme).to.equal(theme);
+    });
+
+    it("should render contact centre triage page with invalid fields from the mobile app", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      const appSessionId = "123456789123456789123456789123456789123456789123456789123456789123456789123456789"; // too long
+      const appErrorCode = ";;***;;"; // unsafe characters
+      req.query.fromURL = validUrl;
+      req.query.appSessionId = appSessionId;
+      req.query.appErrorCode = appErrorCode;
+      contactGet(req as Request, res as Response);
+      // invalid query data not should be passed to the page render
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+      });
+      // invalid query data should not be saved into session
+      expect(req.session.fromURL).to.equal(validUrl);
+      expect(req.session.appSessionId).to.be.undefined;
+      expect(req.session.appErrorCode).to.be.undefined;
+      expect(req.session.theme).to.be.undefined;
+    });
+
+    it("should render contact centre triage page with additional fields from the mobile app from session", () => {
+      const validUrl = "https://home.account.gov.uk/security";
+      const appSessionId = "123456789";
+      const appErrorCode = "ERRORCODE123";
+      const theme = "WaveyTheme";
+      req.session.fromURL = validUrl;
+      req.session.appSessionId = appSessionId;
+      req.session.appErrorCode = appErrorCode;
+      req.session.theme = theme;
+      contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: validUrl,
+        appSessionId,
+        appErrorCode,
+        theme,
       });
     });
 
@@ -62,6 +135,9 @@ describe("Contact GOV.UK One Login controller", () => {
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: undefined,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
       });
     });
 
@@ -69,6 +145,9 @@ describe("Contact GOV.UK One Login controller", () => {
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         fromURL: undefined,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
       });
     });
   });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -3,6 +3,9 @@ import { randomBytes } from "crypto";
 const urlRegex = new RegExp(
   "^(http(s)?://)?(www.)?[-a-zA-Z0-9@:%.+~#=]{2,256}\\.[a-z]{2,6}([-a-zA-Z0-9@:%_+.~#?&//=]*)$"
 );
+const lowerAndUpperCaseLettersAndNumbersMax50 = new RegExp(
+  "^[a-zA-Z0-9_-]{1,50}$"
+);
 
 export function containsNumber(value: string): boolean {
   return value ? /\d/.test(value) : false;
@@ -24,4 +27,8 @@ export function generateNonce(): string {
 
 export function isValidUrl(url: string): boolean {
   return urlRegex.test(url);
+}
+
+export function isSafeString(url: string): boolean {
+  return lowerAndUpperCaseLettersAndNumbersMax50.test(url);
 }

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -3,6 +3,7 @@ import { describe } from "mocha";
 import {
   containsNumber,
   containsNumbersOnly,
+  isSafeString,
   isValidUrl,
   redactPhoneNumber,
 } from "../../../src/utils/strings";
@@ -68,8 +69,9 @@ describe("string-helpers", () => {
       expect(isValidUrl("home.account.gov.uk")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk/security")).to.be.true;
-      expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo")).to.be.true;
-    })
+      expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo"))
+        .to.be.true;
+    });
 
     it("should return false if url is invalid", () => {
       expect(isValidUrl("")).to.be.false;
@@ -79,5 +81,28 @@ describe("string-helpers", () => {
       expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
     });
 
-  })
+    it("should return true if string is safe is invalid", () => {
+      expect(isValidUrl("")).to.be.false;
+      expect(isValidUrl("1")).to.be.false;
+      expect(isValidUrl("qwerty")).to.be.false;
+      expect(isValidUrl("qwerty.gov.&^")).to.be.false;
+      expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
+    });
+  });
+
+  describe("isSafeString", () => {
+    it("letters numbers hyphens and underscores should be accepted", () => {
+      expect(isSafeString("hEllo-12_3")).to.be.true;
+    });
+
+    it("should return false if contains special characters", () => {
+      expect(isSafeString("hEllo***")).to.be.false;
+    });
+
+    it("should return false if over 50 characters", () => {
+      expect(
+        isSafeString("qqqqqqqqqqaaaaaaaaaahhhhhhhhhhhddddddddddooooooooooojjj")
+      ).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## Proposed changes
[OLH-1153] append contact centre params from mobile to session data so they can be used in the contact form link 

### What changed
- Made generic function getValueFromRequestOrSession for extracting fields from the request query or the session
    - this validates the request param with a simple saftey regex before including in the session or page data 
- added the mobile specific fields appSessionId, appErrorCode, & theme

## Testing
unit tests and deployed to dev to confirm FE is accepting the query params and adding them to the session

[OLH-1153]: https://govukverify.atlassian.net/browse/OLH-1153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ