### PR TITLE
OLH-1115: Generate and log phone reference code

### DIFF
--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -6,6 +6,7 @@ import {
   supportPhoneContact,
   showContactGuidance,
 } from "../../config";
+import { generateReferenceCode } from "./../../utils/referenceCode";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 const logger = pino();
@@ -25,6 +26,12 @@ export function contactGet(req: Request, res: Response): void {
     );
   }
 
+  const referenceCode = req.session.referenceCode
+    ? req.session.referenceCode
+    : generateReferenceCode();
+
+  req.session.referenceCode = referenceCode;
+
   // optional fields from mobile
   const theme = getValueFromRequestOrSession(req, "theme");
   const appSessionId = getValueFromRequestOrSession(req, "appSessionId");
@@ -39,6 +46,7 @@ export function contactGet(req: Request, res: Response): void {
     appSessionId,
     appErrorCode,
     theme,
+    referenceCode,
   };
 
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import pino from "pino";
+import { logger } from "../../utils/logger";
 import { isSafeString, isValidUrl } from "./../../utils/strings";
 import {
   supportWebchatContact,
@@ -9,7 +9,6 @@ import {
 import { generateReferenceCode } from "./../../utils/referenceCode";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
-const logger = pino();
 
 export function contactGet(req: Request, res: Response): void {
   const isAuthenticated = req.session?.user?.isAuthenticated;
@@ -36,6 +35,8 @@ export function contactGet(req: Request, res: Response): void {
   const theme = getValueFromRequestOrSession(req, "theme");
   const appSessionId = getValueFromRequestOrSession(req, "appSessionId");
   const appErrorCode = getValueFromRequestOrSession(req, "appErrorCode");
+
+  logContactData(req);
 
   const data = {
     contactWebchatEnabled: supportWebchatContact(),
@@ -81,4 +82,19 @@ const getValueFromRequestOrSession = (
   }
   const valueFromSession = request.session[`${propertyName}`];
   return valueFromSession;
+};
+
+const logContactData = (req: Request) => {
+  logger.info(
+    {
+      fromURL: req.session.fromURL,
+      referenceCode: req.session.referenceCode,
+      appSessionId: req.session.appSessionId,
+      appErrorCode: req.session.appErrorCode,
+      sessionId: req.session.user?.sessionId,
+      persistentSessionId: req.session.user?.persistentSessionId,
+      userAgent: req.headers["user-agent"],
+    },
+    "User visited triage page"
+  );
 };

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -1,7 +1,6 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.contact.title' | translate %}
-{% set refCode = 123456 %}
 {% set hideAccountNavigation = true %}
 {% set hidePhaseBanner = true %}
 
@@ -34,7 +33,7 @@
 
   <p class="govuk-body contact-reference">
     {{'pages.contact.section2.refCode' | translate}}
-    <strong class="contact-reference__code">{{refCode}}</strong>
+    <strong class="contact-reference__code">{{ referenceCode }}</strong>
   </p>
 </section>
 

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -4,8 +4,10 @@ import { Request, Response } from "express";
 import { sinon } from "../../../../test/utils/test-utils";
 import { contactGet } from "../contact-govuk-one-login-controller";
 import { logger } from "../../../utils/logger";
+import * as reference from "../../../utils/referenceCode";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
+const MOCK_REFERENCE_CODE = "123456";
 
 describe("Contact GOV.UK One Login controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -33,6 +35,10 @@ describe("Contact GOV.UK One Login controller", () => {
       status: sandbox.fake(),
     };
 
+    sandbox
+      .stub(reference, "generateReferenceCode")
+      .returns(MOCK_REFERENCE_CODE);
+
     process.env.SUPPORT_TRIAGE_PAGE = "1";
     process.env.SUPPORT_PHONE_CONTACT = "1";
     process.env.SHOW_CONTACT_GUIDANCE = "1";
@@ -59,6 +65,7 @@ describe("Contact GOV.UK One Login controller", () => {
         appSessionId: undefined,
         appErrorCode: undefined,
         theme: undefined,
+        referenceCode: MOCK_REFERENCE_CODE,
       });
       // query data should be saved into session
       expect(req.session.fromURL).to.equal(validUrl);
@@ -82,6 +89,7 @@ describe("Contact GOV.UK One Login controller", () => {
         appSessionId: undefined,
         appErrorCode: undefined,
         theme: undefined,
+        referenceCode: MOCK_REFERENCE_CODE,
       });
     });
 
@@ -105,6 +113,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactPhoneEnabled: true,
         showContactGuidance: true,
         showSignOut: true,
+        referenceCode: MOCK_REFERENCE_CODE,
       });
       // query data should be saved into session
       expect(req.session.fromURL).to.equal(validUrl);
@@ -132,6 +141,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactPhoneEnabled: true,
         showContactGuidance: true,
         showSignOut: true,
+        referenceCode: MOCK_REFERENCE_CODE,
       });
       // invalid query data should not be saved into session
       expect(req.session.fromURL).to.equal(validUrl);
@@ -159,6 +169,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactPhoneEnabled: true,
         showContactGuidance: true,
         showSignOut: true,
+        referenceCode: MOCK_REFERENCE_CODE,
       });
     });
 
@@ -175,6 +186,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactPhoneEnabled: true,
         showContactGuidance: true,
         showSignOut: true,
+        referenceCode: MOCK_REFERENCE_CODE,
       });
     });
 
@@ -189,6 +201,28 @@ describe("Contact GOV.UK One Login controller", () => {
         contactPhoneEnabled: true,
         showContactGuidance: true,
         showSignOut: true,
+        referenceCode: MOCK_REFERENCE_CODE,
+      });
+    });
+
+    it("should keep the reference code from the session if present", () => {
+      req.session = {
+        referenceCode: "654321",
+        user: {
+          isAuthenticated: true,
+        },
+      };
+      contactGet(req as Request, res as Response);
+      expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
+        fromURL: undefined,
+        appSessionId: undefined,
+        appErrorCode: undefined,
+        theme: undefined,
+        contactWebchatEnabled: true,
+        contactPhoneEnabled: true,
+        showContactGuidance: true,
+        showSignOut: true,
+        referenceCode: "654321",
       });
     });
   });

--- a/src/utils/referenceCode.ts
+++ b/src/utils/referenceCode.ts
@@ -1,0 +1,10 @@
+import { zeroPad } from "./strings";
+
+const REFERENCE_CODE_LENGTH = 6;
+
+export type ReferenceCode = string;
+
+export function generateReferenceCode(): ReferenceCode {
+  const random = Math.floor(Math.random() * 1000000 + 1);
+  return zeroPad(random.toString(), REFERENCE_CODE_LENGTH);
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -32,3 +32,7 @@ export function isValidUrl(url: string): boolean {
 export function isSafeString(url: string): boolean {
   return lowerAndUpperCaseLettersAndNumbersMax50.test(url);
 }
+export function zeroPad(input: string, length: number): string {
+  const pad = "0".repeat(length);
+  return (pad + input).slice(-length);
+}

--- a/test/unit/utils/referenceCode.test.ts
+++ b/test/unit/utils/referenceCode.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { generateReferenceCode } from "../../../src/utils/referenceCode";
+
+describe("referenceCode", () => {
+  describe("generateReferenceCode", () => {
+    it("should return a string of length 6", () => {
+      expect(generateReferenceCode().length).to.equal(6);
+    });
+
+    it("should return a code with only numbers", () => {
+      const code = generateReferenceCode();
+      const onlyNumbers = new RegExp("^[0-9]+$");
+      expect(onlyNumbers.test(code)).to.equal(true);
+    });
+  });
+});

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -6,6 +6,7 @@ import {
   isSafeString,
   isValidUrl,
   redactPhoneNumber,
+  zeroPad,
 } from "../../../src/utils/strings";
 
 describe("string-helpers", () => {
@@ -103,6 +104,17 @@ describe("string-helpers", () => {
       expect(
         isSafeString("qqqqqqqqqqaaaaaaaaaahhhhhhhhhhhddddddddddooooooooooojjj")
       ).to.be.false;
+    });
+  });
+
+  describe("zeroPad", () => {
+    it("should return a string of the correct length", () => {
+      const expectedLength = 6;
+      expect(zeroPad("abc", expectedLength).length).to.equal(expectedLength);
+    });
+
+    it("should pad a short string with zeros", () => {
+      expect(zeroPad("123", 6)).to.equal("000123");
     });
   });
 });


### PR DESCRIPTION
## Proposed changes
### What changed

When a user visits the triage page, generate them a reference code and display it on the page. This code is saved to the user's session so they don't get multiple codes if they open several tabs or navigate away from the page and then return.

We also log this code along with information from the user's session. 

### Why did it change

When a user calls our contact centre we need a way to link their phone call to a web or app session. The agent will ask them to read out the reference code and will note it on the support ticket. Logging this code along with the session IDs means someone on 2nd line support can search for the code on a support ticket, find the session IDs and then use those to search for the rest of the user's journey in GOV.UK One Login. 

Note we don't log the user's user ID - we consider this personal data and we're not allowed to record it in Cloudwatch / Splunk. The session identifiers are enough to find the rest of their journey.

### Related links

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've run the app locally and verified the reference code is displayed on the page and the log event contains what I was expecting.

![image](https://github.com/alphagov/di-account-management-frontend/assets/6362602/31f99183-a5af-492b-aad5-e4323984f7cd)


## How to review

The tests for generating the reference code are pretty simple - I included them mostly to document what the requirements are for the code. I'd appreciate any suggestions if you think they need extending.  
