### PR TITLE
OLH-1168: Put the webchat widget on the triage page

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -143,7 +143,7 @@ Mappings:
       LOGSLEVEL: "debug"
       SUPPORTTRIAGEPAGE: "1"
       SUPPORTWEBCHATDEMO: "1"
-      WEBCHATSOURCEURL: "https://dev-chat-loader.smartagent.app/loader/main.js"
+      WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
       SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"
@@ -232,7 +232,6 @@ Mappings:
       SUPPORTPHONECONTACT: "0"
       SHOWCONTACTGUIDANCE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.account.gov.uk/contact-us-from-triage-page"
-
 
 Resources:
   #

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { logger } from "../../utils/logger";
 import { isSafeString, isValidUrl } from "./../../utils/strings";
 import {
+  getWebchatUrl,
   supportWebchatContact,
   supportPhoneContact,
   showContactGuidance,
@@ -22,10 +23,10 @@ export function contactGet(req: Request, res: Response): void {
     ? req.session.referenceCode
     : generateReferenceCode();
   req.session.referenceCode = referenceCode;
-  
+
   const contactEmailServiceUrl =
     buildContactEmailServiceUrlAndSaveDataToSession(req).toString();
-  
+
   logContactDataFromSession(req);
 
   const data = {
@@ -35,6 +36,7 @@ export function contactGet(req: Request, res: Response): void {
     showSignOut: isAuthenticated && !isLoggedOut,
     referenceCode,
     contactEmailServiceUrl: contactEmailServiceUrl,
+    webchatSource: getWebchatUrl(),
   };
 
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -5,6 +5,14 @@
 {% set hidePhaseBanner = true %}
 
 {% block pageContent %}
+
+{% if contactWebchatEnabled %}
+  <script id="smartagent" type="module" defer 
+    src="{{ webchatSource }}" 
+    data-company="hgsgds" data-brand="hgsgds">
+  </script>
+{% endif %}
+
 <h1 class="govuk-heading-xl">{{'pages.contact.header' | translate}}</h1>
 {% if showContactGuidance %} 
   <section>

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -48,6 +48,7 @@ describe("Contact GOV.UK One Login controller", () => {
     process.env.SUPPORT_WEBCHAT_CONTACT = "1";
     process.env.CONTACT_EMAIL_SERVICE_URL =
       "https://signin.account.gov.uk/contact-us";
+    process.env.WEBCHAT_SOURCE_URL = "https://example.com";
   });
 
   afterEach(() => {
@@ -58,6 +59,7 @@ describe("Contact GOV.UK One Login controller", () => {
     delete process.env.SHOW_CONTACT_GUIDANCE;
     delete process.env.SUPPORT_WEBCHAT_CONTACT;
     delete process.env.CONTACT_EMAIL_SERVICE_URL;
+    delete process.env.WEBCHAT_SOURCE_URL;
   });
 
   describe("contactGet", () => {
@@ -74,6 +76,7 @@ describe("Contact GOV.UK One Login controller", () => {
         referenceCode: MOCK_REFERENCE_CODE,
         contactEmailServiceUrl:
           "https://signin.account.gov.uk/contact-us?fromURL=https%3A%2F%2Fhome.account.gov.uk%2Fsecurity",
+        webchatSource: "https://example.com",
       });
       // query data should be saved into session
       expect(req.session.fromURL).to.equal(validUrl);
@@ -96,6 +99,7 @@ describe("Contact GOV.UK One Login controller", () => {
         referenceCode: MOCK_REFERENCE_CODE,
         contactEmailServiceUrl:
           "https://signin.account.gov.uk/contact-us?fromURL=https%3A%2F%2Fhome.account.gov.uk%2Fsecurity",
+        webchatSource: "https://example.com",
       });
     });
 
@@ -118,6 +122,7 @@ describe("Contact GOV.UK One Login controller", () => {
         showContactGuidance: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
+        webchatSource: "https://example.com",
       });
       // query data should be saved into session
       expect(req.session.fromURL).to.equal(validUrl);
@@ -144,6 +149,7 @@ describe("Contact GOV.UK One Login controller", () => {
         showContactGuidance: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
+        webchatSource: "https://example.com",
       });
       // invalid query data should not be saved into session
       expect(req.session.fromURL).to.equal(validUrl);
@@ -170,6 +176,7 @@ describe("Contact GOV.UK One Login controller", () => {
         showContactGuidance: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
+        webchatSource: "https://example.com",
       });
     });
 
@@ -184,6 +191,7 @@ describe("Contact GOV.UK One Login controller", () => {
         showContactGuidance: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
+        webchatSource: "https://example.com",
       });
     });
 
@@ -196,6 +204,7 @@ describe("Contact GOV.UK One Login controller", () => {
         showContactGuidance: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
+        webchatSource: "https://example.com",
       });
     });
 
@@ -214,6 +223,7 @@ describe("Contact GOV.UK One Login controller", () => {
         showSignOut: true,
         referenceCode: "654321",
         contactEmailServiceUrl: "https://signin.account.gov.uk/contact-us",
+        webchatSource: "https://example.com",
       });
     });
 


### PR DESCRIPTION
## Proposed changes

### What changed

Put the webchat widget on the triage page behind the existing feature flag. The supplier's docs for the webchat ask us to put it in the `<head>` section, but this is the same implementation as on the previous webchat demo page - it works fine in the `<body>` and is much easier to implement in our templates.

### Related links

See #1052 and #1056 for the implementation of the webchat demo page.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] Changed an environment variable

## Testing

I've run this locally and verified the webchat opens when I click the widget. ~~Note that the supplier hasn't added any of our domains to their allowlist yet, so this will only work when running the app locally.~~ They've now added our domains to the allowlist so this will work up to staging.

![image](https://github.com/alphagov/di-account-management-frontend/assets/6362602/4f8ca639-b6c0-4b13-920f-ae375eddf310)

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
