### PR TITLE
OLH-1165: Add an example client side JS test

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:unit": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config --exclude \"src/**/*-integration.test.ts\"  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
     "test": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
+    "test:js": "NODE_ENV=development nyc mocha -r dotenv/config \"src/assets/**/*.test.js\"",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
     "watch-sass": "sass --load-path=node_modules/govuk-frontend/govuk --watch src/assets/scss/application.scss dist/public/style.css"

--- a/src/assets/javascript/tests/cookies.test.js
+++ b/src/assets/javascript/tests/cookies.test.js
@@ -1,0 +1,29 @@
+let chai = require("chai")
+let expect = chai.expect
+let mocha = require("mocha")
+let describe = mocha.describe
+const { JSDOM } = require("jsdom");
+
+describe("Cookies function tests", () => {
+  beforeEach(async() => {
+    const dom = new JSDOM("");
+    global.document = dom.window.document;
+    global.window = {};
+    require("../cookies");
+  });
+
+  afterEach(() => {
+
+  })
+
+  it("can check user has given consent for analytics", () => {
+    // Arrange
+    const cookies = window.GOVSignIn.Cookies("trackingId", "analyticsCookieDomain");
+
+    // Act
+    let result = cookies.hasConsentForAnalytics();
+
+    // Assert
+    expect(result).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add an example test for client side JS.

There's a new npm script (`npm run test:js`) that runs mocha looking for *.test.js files in the assets directory.

The example tests use the same `chai` and `mocha` runner and framework that the Typescript tests use. We need to use CommonJS syntax rather than the `import {expect} from "chai"` ES6 syntax, but that's a difference we can manage.

I've not yet added this script to the list of ones which are run in `npm run test` - we can do that once we have some more substantial tests.

### Why did it change

We need to have unit tests for our client side JS before we do any significant work on either the webchat or GA4.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

Run the new tests with `npm run test:js`

## How to review

I've done very little work with client side JS. This looks sensible to me and the [Chai docs](https://www.chaijs.com/guide/plugins/) suggest that it's capable of managing client side JS, but this is a very simple example. We should consider if it'll work with the module system the rest of our client side code uses.

@andrew-moores I added a test for a simple method in the cookies module to illustrate how we can test our client side code.