### PR TITLE
Olh 1122 emit an audit event when a user visits the triage page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "4566:4566"
     environment:
-      - SERVICES=kms,sns,dynamodb
+      - SERVICES=kms,sns,dynamodb,sqs
       - HOSTNAME_EXTERNAL=localhost
       - DEBUG=0
       - KMS_PROVIDER=local-kms
@@ -50,7 +50,9 @@ services:
       - SESSION_STORE_TABLE_NAME=${SESSION_STORE_TABLE_NAME}
       - SUPPORT_ACTIVITY_LOG=${SUPPORT_ACTIVITY_LOG}
       - DEBUG=express-session
-      - LOCALSTACK_HOSTNAME=host.docker.internal
+      - LOCALSTACK_HOSTNAME=localstack
+      - AWS_REGION=eu-west-2
+      - AUDIT_QUEUE_URL=http://localstack:4566/audit-events
     restart: on-failure
     depends_on:
       localstack:

--- a/localstack/provision.sh
+++ b/localstack/provision.sh
@@ -66,3 +66,6 @@ aws --endpoint-url http://localhost:4566 dynamodb update-time-to-live \
   --table-name account-mgmt-frontend-SessionStore \
   --region eu-west-2 \
   --time-to-live-specification Enabled=true,AttributeName=expires
+
+aws sqs --endpoint-url http://localhost:4566 create-queue --queue-name audit-events \
+  --region eu-west-2

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.415.0",
+        "@aws-sdk/client-sqs": "^3.382.0",
         "@aws-sdk/util-dynamodb": "^3.415.0",
         "aws-sdk": "2.1460.0",
         "axios": "^1.5.0",
@@ -201,6 +202,458 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.430.0.tgz",
+      "integrity": "sha512-0ptTmaRtJsia5dgs8CGV722ct3u6KSTfr5UvQr/q+OcLjesZYkZDbVgKGC82rfJEvAwtlHsP5aP/nI6jxZAHlg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.430.0",
+        "@aws-sdk/credential-provider-node": "3.430.0",
+        "@aws-sdk/middleware-host-header": "3.429.0",
+        "@aws-sdk/middleware-logger": "3.428.0",
+        "@aws-sdk/middleware-recursion-detection": "3.428.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.428.0",
+        "@aws-sdk/middleware-signing": "3.428.0",
+        "@aws-sdk/middleware-user-agent": "3.428.0",
+        "@aws-sdk/region-config-resolver": "3.430.0",
+        "@aws-sdk/types": "3.428.0",
+        "@aws-sdk/util-endpoints": "3.428.0",
+        "@aws-sdk/util-user-agent-browser": "3.428.0",
+        "@aws-sdk/util-user-agent-node": "3.430.0",
+        "@smithy/config-resolver": "^2.0.15",
+        "@smithy/fetch-http-handler": "^2.2.3",
+        "@smithy/hash-node": "^2.0.11",
+        "@smithy/invalid-dependency": "^2.0.11",
+        "@smithy/md5-js": "^2.0.11",
+        "@smithy/middleware-content-length": "^2.0.13",
+        "@smithy/middleware-endpoint": "^2.1.2",
+        "@smithy/middleware-retry": "^2.0.17",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/smithy-client": "^2.1.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.15",
+        "@smithy/util-defaults-mode-node": "^2.0.20",
+        "@smithy/util-retry": "^2.0.4",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.430.0.tgz",
+      "integrity": "sha512-NxQJkTZCgl6LpdY12MCwsqGned6Ax19WsTCGLEiA/tsNE4vNrYLHHBR317G0sGWbIUQuhwsoM7wIrqJO7CacuQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.429.0",
+        "@aws-sdk/middleware-logger": "3.428.0",
+        "@aws-sdk/middleware-recursion-detection": "3.428.0",
+        "@aws-sdk/middleware-user-agent": "3.428.0",
+        "@aws-sdk/region-config-resolver": "3.430.0",
+        "@aws-sdk/types": "3.428.0",
+        "@aws-sdk/util-endpoints": "3.428.0",
+        "@aws-sdk/util-user-agent-browser": "3.428.0",
+        "@aws-sdk/util-user-agent-node": "3.430.0",
+        "@smithy/config-resolver": "^2.0.15",
+        "@smithy/fetch-http-handler": "^2.2.3",
+        "@smithy/hash-node": "^2.0.11",
+        "@smithy/invalid-dependency": "^2.0.11",
+        "@smithy/middleware-content-length": "^2.0.13",
+        "@smithy/middleware-endpoint": "^2.1.2",
+        "@smithy/middleware-retry": "^2.0.17",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/smithy-client": "^2.1.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.15",
+        "@smithy/util-defaults-mode-node": "^2.0.20",
+        "@smithy/util-retry": "^2.0.4",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.430.0.tgz",
+      "integrity": "sha512-njUY3QeZH0CG+tG/6jhoG+Zr7rI1aGoVkZi3l6woKTz57hIlkwu2jQlLbJujm7PKrLhPaN5+4AqBQuHFVgMobw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.430.0",
+        "@aws-sdk/middleware-host-header": "3.429.0",
+        "@aws-sdk/middleware-logger": "3.428.0",
+        "@aws-sdk/middleware-recursion-detection": "3.428.0",
+        "@aws-sdk/middleware-sdk-sts": "3.428.0",
+        "@aws-sdk/middleware-signing": "3.428.0",
+        "@aws-sdk/middleware-user-agent": "3.428.0",
+        "@aws-sdk/region-config-resolver": "3.430.0",
+        "@aws-sdk/types": "3.428.0",
+        "@aws-sdk/util-endpoints": "3.428.0",
+        "@aws-sdk/util-user-agent-browser": "3.428.0",
+        "@aws-sdk/util-user-agent-node": "3.430.0",
+        "@smithy/config-resolver": "^2.0.15",
+        "@smithy/fetch-http-handler": "^2.2.3",
+        "@smithy/hash-node": "^2.0.11",
+        "@smithy/invalid-dependency": "^2.0.11",
+        "@smithy/middleware-content-length": "^2.0.13",
+        "@smithy/middleware-endpoint": "^2.1.2",
+        "@smithy/middleware-retry": "^2.0.17",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/smithy-client": "^2.1.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.15",
+        "@smithy/util-defaults-mode-node": "^2.0.20",
+        "@smithy/util-retry": "^2.0.4",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.428.0.tgz",
+      "integrity": "sha512-e6fbY174Idzw0r5ZMT1qkDh+dpOp1DX3ickhr7J6ipo3cUGLI45Y5lnR9nYXWfB5o/wiNv4zXgN+Y3ORJJHzyA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.430.0.tgz",
+      "integrity": "sha512-m3NcmDyVYr/w8RV9kMArrA/0982aXMsvoSXi4wFVbgg/T5hO+6i5CY7fB/0xpKIuEJ+rw63rYNnBzLwwW48kWg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.428.0",
+        "@aws-sdk/credential-provider-process": "3.428.0",
+        "@aws-sdk/credential-provider-sso": "3.430.0",
+        "@aws-sdk/credential-provider-web-identity": "3.428.0",
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.430.0.tgz",
+      "integrity": "sha512-ItOHJcqOhpI0QM+aho5uMrk2ZP34hsdisMHxd8/6FT41U8TOe9kQKaZ2l2AsVf4QuM6RJe2LangcVGGstCf8Sw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.428.0",
+        "@aws-sdk/credential-provider-ini": "3.430.0",
+        "@aws-sdk/credential-provider-process": "3.428.0",
+        "@aws-sdk/credential-provider-sso": "3.430.0",
+        "@aws-sdk/credential-provider-web-identity": "3.428.0",
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.428.0.tgz",
+      "integrity": "sha512-UG2S2/4Wrskbkbgt9fBlnzwQ2hfTXvLJwUgGOluSOf6+mGCcoDku4zzc9EQdk1MwN5Us+ziyMrIMNY5sbdLg6g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.430.0.tgz",
+      "integrity": "sha512-6de/aH9OFI+Ah7hL4alrZFqiNw5D6F+R92tLbIpFRQg7DxO/TuQTTtK94mLkft/AP/mGzVVBENjsyS1nJt166w==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.430.0",
+        "@aws-sdk/token-providers": "3.430.0",
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.428.0.tgz",
+      "integrity": "sha512-ueuUPPlrJFvtDUVTGnClUGt1wxCbEiKArknah/w9cfcc/c1HtFd/M7x/z2Sm0gSItR45sVcK54qjzmhm29DMzg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.429.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.429.0.tgz",
+      "integrity": "sha512-3v9WoDCmbfH28znQ43cQLvLlm8fhJFIDJLW19moFI8QbXMv85yojGEphBMlT2XZUw79+tyh7GWLFaNugYZ1o9A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.428.0.tgz",
+      "integrity": "sha512-1P0V0quL9u2amdNOn6yYT7/ToQUmkLJqCKHPxsRyDB829vBThWndvvH5MkoItj/VgE1zWqMtrzN3xtzD7zx6Qg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.428.0.tgz",
+      "integrity": "sha512-xC0OMduCByyRdiQz324RXy4kunnCG4LUJCfvdoegM33Elp9ex0D3fcfO1mUgV8qiLwSennIsSRVXHuhNxE2HZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.428.0.tgz",
+      "integrity": "sha512-Uutl2niYXTnNP8v84v6umWDHD5no7d5/OqkZE1DsmeKR/dje90J5unJWf7MOsqvYm0JGDEWF4lk9xGVyqsw+Aw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.428.0",
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.428.0.tgz",
+      "integrity": "sha512-oMSerTPwtsQAR7fIU/G0b0BA30wF+MC4gZSrJjbypF8MK8nPC2yMfKLR8+QavGOGEW7rUMQ0uklThMTTwQEXNQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-middleware": "^2.0.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.428.0.tgz",
+      "integrity": "sha512-+GAhObeHRick2D5jr3YkPckjcggt5v6uUVtEUQW2AdD65cE5PjIvmksv6FuM/mME/9nNA+wufQnHbLI8teLeaw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@aws-sdk/util-endpoints": "3.428.0",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+      "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.430.0.tgz",
+      "integrity": "sha512-vE+QnqG0A4MWhMEFXXPg8gPXjw03b4Q3XZbHyrANoZ+tVrzh8JhpHIcbkesGh6WrjirNqId0UghzI9VanKxsLw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.429.0",
+        "@aws-sdk/middleware-logger": "3.428.0",
+        "@aws-sdk/middleware-recursion-detection": "3.428.0",
+        "@aws-sdk/middleware-user-agent": "3.428.0",
+        "@aws-sdk/types": "3.428.0",
+        "@aws-sdk/util-endpoints": "3.428.0",
+        "@aws-sdk/util-user-agent-browser": "3.428.0",
+        "@aws-sdk/util-user-agent-node": "3.430.0",
+        "@smithy/config-resolver": "^2.0.15",
+        "@smithy/fetch-http-handler": "^2.2.3",
+        "@smithy/hash-node": "^2.0.11",
+        "@smithy/invalid-dependency": "^2.0.11",
+        "@smithy/middleware-content-length": "^2.0.13",
+        "@smithy/middleware-endpoint": "^2.1.2",
+        "@smithy/middleware-retry": "^2.0.17",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.15",
+        "@smithy/util-defaults-mode-node": "^2.0.20",
+        "@smithy/util-retry": "^2.0.4",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.428.0.tgz",
+      "integrity": "sha512-4T0Ps2spjg3qbWE6ZK13Vd3FnzpfliaiotqjxUK5YhjDrKXeT36HJp46JhDupElQuHtTkpdiJOSYk2lvY2H4IA==",
+      "dependencies": {
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.428.0.tgz",
+      "integrity": "sha512-ToKMhYlUWJ0YrbggpJLZeyZZNDXtQ4NITxqo/oeGltTT9KG4o/LqVY59EveV0f8P32ObDyj9Vh1mnjxeo3DxGw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.428.0.tgz",
+      "integrity": "sha512-qlc2UoGsmCpuh1ErY3VayZuAGl74TWWcLmhhQMkeByFSb6KooBlwOmDpDzJRtgwJoe0KXnyHBO6lzl9iczcozg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/types": "^2.3.5",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.430.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.430.0.tgz",
+      "integrity": "sha512-DPpFPL3mFMPtipFxjY7TKQBjnhmsPzYCr4Y+qna0oR6ij8jZOz2ILQDK33GxTRNh3+bV9YYbx+ZGDOnxoK5Mhw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.414.0",
@@ -525,6 +978,38 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.428.0.tgz",
+      "integrity": "sha512-pYaBV9H4NGbVB5cqVOc7GoBpo/4BpTwMDpNzWWThENFzlxndzMLHLmQlSfPQoRRUIbLL39L3YeqfrSFwwzVspQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.428.0",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.428.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.428.0.tgz",
+      "integrity": "sha512-4T0Ps2spjg3qbWE6ZK13Vd3FnzpfliaiotqjxUK5YhjDrKXeT36HJp46JhDupElQuHtTkpdiJOSYk2lvY2H4IA==",
+      "dependencies": {
+        "@smithy/types": "^2.3.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
@@ -1414,11 +1899,11 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.8.tgz",
-      "integrity": "sha512-2SOdVj5y0zE37Y9scSXoizoxgi6mgnDabi7a/SOfhl0p+50I0rIkuJTfyAuTPDtQ7e5dD6tSZPCLB3c/YM6Zig==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.11.tgz",
+      "integrity": "sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1431,14 +1916,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.9.tgz",
-      "integrity": "sha512-QBkGPLUqyPmis9Erz8v4q5lo/ErnF7+GD5WZHa6JZiXopUPfaaM+B21n8gzS5xCkIXZmnwzNQhObP9xQPu8oqQ==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.15.tgz",
+      "integrity": "sha512-a2Pfocla5nSrG2RyB8i20jcWgMyR71TUeFKm8pmrnZotr/X22tlg4y/EhSvBK2oTE8MKHlKh4YdpDO2AryJbGQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.11",
-        "@smithy/types": "^2.3.2",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.1",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1451,14 +1936,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.11.tgz",
-      "integrity": "sha512-uJJs8dnM5iXkn8a2GaKvlKMhcOJ+oJPYqY9gY3CM/EieCVObIDjxUtR/g8lU/k/A+OauA78GzScAfulmFjPOYA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.17.tgz",
+      "integrity": "sha512-2XcD414yrwbxxuYueTo7tzLC2/w3jj9FZqfenpv3MQkocdOEmuOVS0v9WHsY/nW6V+2EcR340rj/z5HnvsHncQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.11",
-        "@smithy/property-provider": "^2.0.9",
-        "@smithy/types": "^2.3.2",
-        "@smithy/url-parser": "^2.0.8",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1487,13 +1972,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.4.tgz",
-      "integrity": "sha512-SL24M9W5ERByoXaVicRx+bj9GJVujDnPn+QO7GY7adhY0mPGa6DSF58pVKsgIh4r5Tx/k3SWCPlH4BxxSxA/fQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.3.tgz",
+      "integrity": "sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.4",
-        "@smithy/querystring-builder": "^2.0.8",
-        "@smithy/types": "^2.3.2",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
@@ -1504,11 +1989,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.8.tgz",
-      "integrity": "sha512-yZL/nmxZzjZV5/QX5JWSgXlt0HxuMTwFO89CS++jOMMPiCMZngf6VYmtNdccs8IIIAMmfQeTzwu07XgUE/Zd3Q==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.11.tgz",
+      "integrity": "sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -1523,11 +2008,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.8.tgz",
-      "integrity": "sha512-88VOS7W3KzUz/bNRc+Sl/F/CDIasFspEE4G39YZRHIh9YmsXF7GUyVaAKURfMNulTie62ayk6BHC9O0nOBAVgQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.11.tgz",
+      "integrity": "sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -1552,13 +2037,28 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.10.tgz",
-      "integrity": "sha512-EGSbysyA4jH0p3xI6G0jdXoj9Iz9GUnAta6aEaHtXm3wVWtenRf80y2TeVvNkVSr5jwKOdSCjKIRI2l1A/oZLA==",
+    "node_modules/@smithy/md5-js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.11.tgz",
+      "integrity": "sha512-YBIv+e95qeGvQA05ucwstmTeQ/bUzWgU+nO2Ffmif5awu6IzSR0Jfk3XLYh4mdy7f8DCgsn8qA63u7N9Lu0+5A==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.4",
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/md5-js/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.13.tgz",
+      "integrity": "sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1571,14 +2071,16 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.8.tgz",
-      "integrity": "sha512-yOpogfG2d2V0cbJdAJ6GLAWkNOc9pVsL5hZUfXcxJu408N3CUCsXzIAFF6+70ZKSE+lCfG3GFErcSXv/UfUbjw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.2.tgz",
+      "integrity": "sha512-dua4r2EbSTRzNefz72snz+KDuXN73RCe1K+rGeemzUyYemxuh1jujFbLQbTU6DVlTgHkhtrbH0+kdOFY/SV4Qg==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.8",
-        "@smithy/types": "^2.3.2",
-        "@smithy/url-parser": "^2.0.8",
-        "@smithy/util-middleware": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/shared-ini-file-loader": "^2.2.1",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1591,16 +2093,16 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.11.tgz",
-      "integrity": "sha512-pknfokumZ+wvBERSuKAI2vVr+aK3ZgPiWRg6+0ZG4kKJogBRpPmDGWw+Jht0izS9ZaEbIobNzueIb4wD33JJVg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.17.tgz",
+      "integrity": "sha512-ZYVU1MmshCTbEKTNc5h7/Pps1vhH5C7hRclQWnAbVYKkIT+PEGu9dSVqprzEo/nlMA8Zv4Dj5Y+fv3pRnUwElw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.11",
-        "@smithy/protocol-http": "^3.0.4",
-        "@smithy/service-error-classification": "^2.0.1",
-        "@smithy/types": "^2.3.2",
-        "@smithy/util-middleware": "^2.0.1",
-        "@smithy/util-retry": "^2.0.1",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-middleware": "^2.0.4",
+        "@smithy/util-retry": "^2.0.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -1614,11 +2116,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.8.tgz",
-      "integrity": "sha512-Is0sm+LiNlgsc0QpstDzifugzL9ehno1wXp109GgBgpnKTK3j+KphiparBDI4hWTtH9/7OUsxuspNqai2yyhcg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.11.tgz",
+      "integrity": "sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1631,11 +2133,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.1.tgz",
-      "integrity": "sha512-UexsfY6/oQZRjTQL56s9AKtMcR60tBNibSgNYX1I2WXaUaXg97W9JCkFyth85TzBWKDBTyhLfenrukS/kyu54A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.5.tgz",
+      "integrity": "sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1648,13 +2150,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.11.tgz",
-      "integrity": "sha512-CaR1dciSSGKttjhcefpytYjsfI/Yd5mqL8am4wfmyFCDxSiPsvnEWHl8UjM/RbcAjX0klt+CeIKPSHEc0wGvJA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.2.tgz",
+      "integrity": "sha512-tbYh/JK/ddxKWYTtjLgap0juyivJ0wCvywMqINb54zyOVHoKYM6iYl7DosQA0owFaNp6GAx1lXFjqGz7L2fAqA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.9",
-        "@smithy/shared-ini-file-loader": "^2.0.10",
-        "@smithy/types": "^2.3.2",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/shared-ini-file-loader": "^2.2.1",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1667,14 +2169,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.4.tgz",
-      "integrity": "sha512-8Rw/AusvWDyC6SK8esAcVBeTlQHf94NMFv805suFUJCQ2gwlh0oLDNh+6s2MDOrxcjvLxjjzv1mytM0Mt+0cPQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.7.tgz",
+      "integrity": "sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.8",
-        "@smithy/protocol-http": "^3.0.4",
-        "@smithy/querystring-builder": "^2.0.8",
-        "@smithy/types": "^2.3.2",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1687,11 +2189,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.9.tgz",
-      "integrity": "sha512-25pPZ8f8DeRwYI5wbPRZaoMoR+3vrw8DwbA0TjP+GsdiB2KxScndr4HQehiJ5+WJ0giOTWhLz0bd+7Djv1qpUQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.12.tgz",
+      "integrity": "sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1704,11 +2206,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.4.tgz",
-      "integrity": "sha512-CGfSWk6TRlbwa8YgrSXdn80Yu7pov3EV/h7TSfiCHhq6/LO3WymmqnzgH1f0qV2bdTDipIkTNp5dGCGN3Af/5g==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.7.tgz",
+      "integrity": "sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1721,11 +2223,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.8.tgz",
-      "integrity": "sha512-+vzIMwjC8Saz97/ptPn+IJRCRRZ+pP95ZIWDRqEqZV/a6hiKbaFoMSa2iCKsnKzR696U2JZXrDqMu3e/FD1+2g==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.11.tgz",
+      "integrity": "sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -1739,11 +2241,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.8.tgz",
-      "integrity": "sha512-ArbanNuR7O/MmTd90ZqhDqGOPPDYmxx3huHxD+R3cuCnazcK/1tGQA+SnnR5307T7ZRb5WTpB6qBggERuibVSA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.11.tgz",
+      "integrity": "sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1756,22 +2258,22 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.1.tgz",
-      "integrity": "sha512-QHa9+t+v4s0cMuDCcbjIJN67mNZ42/+fc3jKe8P6ZMPXZl5ksKk6a8vhZ/m494GZng5eFTc3OePv+NF9cG83yg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.4.tgz",
+      "integrity": "sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==",
       "dependencies": {
-        "@smithy/types": "^2.3.2"
+        "@smithy/types": "^2.3.5"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.10.tgz",
-      "integrity": "sha512-jWASteSezRKohJ7GdA7pHDvmr7Q7tw3b5mu3xLHIkZy/ICftJ+O7aqNaF8wklhI7UNFoQ7flFRM3Rd0KA+1BbQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.1.tgz",
+      "integrity": "sha512-eAYajwo2eTTVU5KPX90+V6ccfrWphrzcUwOt7n9pLOMBO0fOKlRVshbvCBqfRCxEn7OYDGH6TsL3yrx+hAjddA==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1807,13 +2309,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.5.tgz",
-      "integrity": "sha512-7S865uKzsxApM8W8Q6zkij7tcUFgaG8PuADMFdMt1yL/ku3d0+s6Zwrg3N7iXCPM08Gu/mf0BIfTXIu/9i450Q==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.11.tgz",
+      "integrity": "sha512-okjMbuBBCTiieK665OFN/ap6u9+Z9z55PMphS5FYCsS6Zfp137Q3qlnt0OgBAnUVnH/mNGyoJV0LBX9gkTWptg==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.1",
-        "@smithy/types": "^2.3.2",
-        "@smithy/util-stream": "^2.0.11",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-stream": "^2.0.16",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1826,9 +2328,9 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/types": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.2.tgz",
-      "integrity": "sha512-iH0cdKi7HQlzfAM3w2shFk/qZYKAqJWswtpmQpPtlruF+uFZeGEpMJjgDRyhWiddfVM4e2oP4nMaOBsMy6lXgg==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.5.tgz",
+      "integrity": "sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1842,12 +2344,12 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.8.tgz",
-      "integrity": "sha512-wQw7j004ScCrBRJ+oNPXlLE9mtofxyadSZ9D8ov/rHkyurS7z1HTNuyaGRj6OvKsEk0SVQsuY0C9+EfM75XTkw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.11.tgz",
+      "integrity": "sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.8",
-        "@smithy/types": "^2.3.2",
+        "@smithy/querystring-parser": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -1936,13 +2438,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.9.tgz",
-      "integrity": "sha512-JONLJVQWT8165XoSV36ERn3SVlZLJJ4D6IeGsCSePv65Uxa93pzSLE0UMSR9Jwm4zix7rst9AS8W5QIypZWP8Q==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.15.tgz",
+      "integrity": "sha512-2raMZOYKSuke7QlDg/HDcxQdrp0zteJ8z+S0B9Rn23J55ZFNK1+IjG4HkN6vo/0u3Xy/JOdJ93ibiBSB8F7kOw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.9",
-        "@smithy/smithy-client": "^2.1.5",
-        "@smithy/types": "^2.3.2",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.11",
+        "@smithy/types": "^2.3.5",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -1956,16 +2458,16 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.11.tgz",
-      "integrity": "sha512-tmqjNsfj+bgZN6jXBe6efZnukzILA7BUytHkzqikuRLNtR+0VVchQHvawD0w6vManh76rO81ydhioe7i4oBzuA==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.20.tgz",
+      "integrity": "sha512-kJjcZ/Lzvs3sPDKBwlhZsFFcgPNIpB3CMb6/saCakawRzo0E+JkyS3ZZRjVR3ce29yHtwoP/0YLKC1PeH0Dffg==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.9",
-        "@smithy/credential-provider-imds": "^2.0.11",
-        "@smithy/node-config-provider": "^2.0.11",
-        "@smithy/property-provider": "^2.0.9",
-        "@smithy/smithy-client": "^2.1.5",
-        "@smithy/types": "^2.3.2",
+        "@smithy/config-resolver": "^2.0.15",
+        "@smithy/credential-provider-imds": "^2.0.17",
+        "@smithy/node-config-provider": "^2.1.2",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1994,11 +2496,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.1.tgz",
-      "integrity": "sha512-LnsBMi0Mg3gfz/TpNGLv2Jjcz2ra1OX5HR/4IaCepIYmtPQzqMWDdhX/XTW1LS8OZ0xbQuyQPcHkQ+2XkhWOVQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.4.tgz",
+      "integrity": "sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==",
       "dependencies": {
-        "@smithy/types": "^2.3.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2011,12 +2513,12 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.1.tgz",
-      "integrity": "sha512-naj4X0IafJ9yJnVJ58QgSMkCNLjyQOnyrnKh/T0f+0UOUxJiT8vuFn/hS7B/pNqbo2STY7PyJ4J4f+5YqxwNtA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.4.tgz",
+      "integrity": "sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.1",
-        "@smithy/types": "^2.3.2",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2029,13 +2531,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.11.tgz",
-      "integrity": "sha512-2MeWfqSpZKdmEJ+tH8CJQSgzLWhH5cmdE24X7JB0hiamXrOmswWGGuPvyj/9sQCTclo57pNxLR2p7KrP8Ahiyg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.16.tgz",
+      "integrity": "sha512-b5ZSRh1KzUzC7LoJcpfk7+iXGoRr3WylEfmPd4FnBLm90OwxSB9VgK1fDZwicfYxSEvWHdYXgvvjPtenEYBBhw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.1.4",
-        "@smithy/node-http-handler": "^2.1.4",
-        "@smithy/types": "^2.3.2",
+        "@smithy/fetch-http-handler": "^2.2.3",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@aws-sdk/client-dynamodb": "^3.415.0",
     "@aws-sdk/util-dynamodb": "^3.415.0",
     "aws-sdk": "2.1460.0",
+    "@aws-sdk/client-sqs": "^3.382.0",
     "axios": "^1.5.0",
     "base64url": "3.0.1",
     "body-parser": "^1.20.2",

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -9,28 +9,158 @@ import {
   supportWebchatContact,
 } from "../../config";
 import { generateReferenceCode } from "../../utils/referenceCode";
+import { eventService } from "./event-service";
+import { AuditEvent, Extensions, Platform, User } from "./types";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
+const MISSING_SESSION_VALUE_SPECIAL_CASE : string = "";
 
 export function contactGet(req: Request, res: Response): void {
-  const isAuthenticated = req.session?.user?.isAuthenticated;
+  updateSessionFromQueryParams(req.session, req.query);
+  const audit_event = buildAuditEvent(req);
+  logUserVisitsContactPage(audit_event);
+  sendUserVisitsContactPageAuditEvent(audit_event);
+  render(req, res);
+}
+
+const updateSessionFromQueryParams = (session: any, queryParams: any): void => {
+  if (isValidUrl(queryParams.fromURL as string)) {
+    session.fromURL = queryParams.fromURL;
+  } else {
+    logger.error("fromURL in request query for contact-govuk-one-login page did not pass validation");
+  }
+
+  copySafeQueryParamToSession(session, queryParams, 'theme');
+  copySafeQueryParamToSession(session, queryParams, 'appSessionId');
+  copySafeQueryParamToSession(session, queryParams, 'appErrorCode');
+
+  if (!session.referenceCode) {
+    session.referenceCode = generateReferenceCode();
+  }
+}
+
+const copySafeQueryParamToSession = (session: any, queryParams: any, paramName: string) => {
+  if (queryParams[paramName] && isSafeString(queryParams[paramName] as string)) {
+    session[paramName] = queryParams[paramName];
+  } else {
+    logger.error(`${paramName} in request query for contact-govuk-one-login page did not pass validation`);
+  }
+};
+
+const buildAuditEvent = (req: Request): AuditEvent => {
+  const session: any = req.session;
+  let sessionId: string;
+
+  if (userHasSignedIntoHomeRelyingParty(session)) {
+    sessionId = session.user.sessionId;
+  } else {
+    sessionId = MISSING_SESSION_VALUE_SPECIAL_CASE;
+  }
+
+  let persistentSessionId: string;
+
+  if (session.user?.persistentSessionId) {
+    persistentSessionId = session.user.persistentSessionId;
+  } else {
+    persistentSessionId = MISSING_SESSION_VALUE_SPECIAL_CASE;
+  }
+
+  const user: User = {
+    session_id: sessionId,
+    persistent_session_id: persistentSessionId,
+  };
+
+  const platform: Platform = {
+    user_agent: req.headers["user-agent"],
+  };
+
+  let appSessionId: string;
+
+  if (userHasComeFromTheApp(session)) {
+    appSessionId = req.session.appSessionId;
+  } else {
+    appSessionId = MISSING_SESSION_VALUE_SPECIAL_CASE;
+  }
+
+  const extensions: Extensions = {
+    from_url: req.session.fromURL,
+    app_error_code: req.session.appErrorCode,
+    app_session_id: appSessionId,
+    reference_code: req.session.referenceCode,
+  };
+
+  return {
+    timestamp: req.session.timestamp,
+    event_name: "HOME_TRIAGE_PAGE_VISIT",
+    component_id: "HOME",
+    user: user,
+    platform: platform,
+    extensions: extensions,
+  };
+}
+
+const userHasSignedIntoHomeRelyingParty = (session: any): boolean => {
+  return !!session.user?.sessionId;
+}
+
+const userHasComeFromTheApp = (session: any): boolean => {
+  return !!session.appSessionId;
+}
+
+const buildContactEmailServiceUrl = (req: Request): URL => {
+  const contactEmailServiceUrl: URL = new URL(getContactEmailServiceUrl());
+
+  if (req.session.fromURL) {
+    contactEmailServiceUrl.searchParams.append("fromURL", req.session.fromURL);
+  } else {
+    logger.info(
+      "Request to contact-govuk-one-login page did not contain a valid fromURL in the request or session"
+    );
+  }
+
+  if (req.session.theme) {
+    contactEmailServiceUrl.searchParams.append("theme", req.session.theme);
+  }
+
+  if (req.session.appSessionId) {
+    contactEmailServiceUrl.searchParams.append("appSessionId", req.session.appSessionId);
+  }
+
+  if (req.session.appErrorCode) {
+    contactEmailServiceUrl.searchParams.append("appErrorCode", req.session.appErrorCode);
+  }
+
+  return contactEmailServiceUrl;
+};
+
+const logUserVisitsContactPage = (event: AuditEvent) => {
+  logger.info(
+    {
+      fromURL: event.extensions.from_url,
+      referenceCode: event.extensions.reference_code,
+      appSessionId: event.extensions.app_session_id,
+      appErrorCode: event.extensions.app_error_code,
+      sessionId: event.user.session_id,
+      persistentSessionId: event.user.persistent_session_id,
+      userAgent: event.platform.user_agent,
+    },
+    "User visited triage page"
+  );
+};
+
+const sendUserVisitsContactPageAuditEvent = (audit_event: AuditEvent) => {
+  eventService().send(audit_event);
+};
+
+const render = (req: Request, res: Response): void => {
+  const { originalUrl, language, protocol, hostname } = req;
+  const baseUrl = protocol + "://" + hostname;
+  const isAuthenticated = req.session.user?.isAuthenticated;
   let isLoggedOut = req.cookies?.lo;
   if (typeof isLoggedOut === "string") {
     isLoggedOut = JSON.parse(isLoggedOut);
   }
-
-  const { originalUrl, language, protocol, hostname } = req;
-  const baseUrl = protocol + "://" + hostname;
-
-  const referenceCode = req.session.referenceCode
-    ? req.session.referenceCode
-    : generateReferenceCode();
-  req.session.referenceCode = referenceCode;
-
-  const contactEmailServiceUrl =
-    buildContactEmailServiceUrlAndSaveDataToSession(req).toString();
-
-  logContactDataFromSession(req);
+  const referenceCode = req.session.referenceCode;
 
   const data = {
     contactWebchatEnabled: supportWebchatContact(),
@@ -38,7 +168,7 @@ export function contactGet(req: Request, res: Response): void {
     showContactGuidance: showContactGuidance(),
     showSignOut: isAuthenticated && !isLoggedOut,
     referenceCode,
-    contactEmailServiceUrl: contactEmailServiceUrl,
+    contactEmailServiceUrl: buildContactEmailServiceUrl(req).toString(),
     webchatSource: getWebchatUrl(),
     currentUrl: originalUrl,
     baseUrl,
@@ -46,77 +176,5 @@ export function contactGet(req: Request, res: Response): void {
   };
 
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);
-}
-
-const buildContactEmailServiceUrlAndSaveDataToSession = (req: Request): URL => {
-  const fromURL = getFromUrlAndSaveIt(req);
-  if (!fromURL) {
-    logger.info(
-      "Request to contact-govuk-one-login page did not contain a valid fromURL in the request or session"
-    );
-  }
-  // optional fields from mobile
-  const theme = getValueFromRequestOrSession(req, "theme");
-  const appSessionId = getValueFromRequestOrSession(req, "appSessionId");
-  const appErrorCode = getValueFromRequestOrSession(req, "appErrorCode");
-
-  const contactEmailServiceUrl: URL = new URL(getContactEmailServiceUrl());
-
-  if (fromURL) {
-    contactEmailServiceUrl.searchParams.append("fromURL", fromURL);
-  }
-  if (theme) {
-    contactEmailServiceUrl.searchParams.append("theme", theme);
-  }
-  if (appSessionId) {
-    contactEmailServiceUrl.searchParams.append("appSessionId", appSessionId);
-  }
-  if (appErrorCode) {
-    contactEmailServiceUrl.searchParams.append("appErrorCode", appErrorCode);
-  }
-  return contactEmailServiceUrl;
 };
 
-const getFromUrlAndSaveIt = (request: Request): string => {
-  const fromURLFromRequest = request.query.fromURL as string;
-  if (fromURLFromRequest && isValidUrl(fromURLFromRequest)) {
-    request.session.fromURL = fromURLFromRequest;
-    return fromURLFromRequest;
-  } else if (fromURLFromRequest) {
-    logger.error(
-      "fromURL in request query for contact-govuk-one-login page did not pass validation"
-    );
-  }
-  return request.session.fromURL;
-};
-
-const getValueFromRequestOrSession = (
-  request: Request,
-  propertyName: string
-): string => {
-  const valueFromRequest = request.query[`${propertyName}`] as string;
-  if (valueFromRequest && isSafeString(valueFromRequest)) {
-    request.session[`${propertyName}`] = valueFromRequest;
-    return valueFromRequest;
-  } else if (valueFromRequest) {
-    logger.error(
-      `${propertyName} in request query for contact-govuk-one-login page did not pass validation`
-    );
-  }
-  return request.session[`${propertyName}`];
-};
-
-const logContactDataFromSession = (req: Request) => {
-  logger.info(
-    {
-      fromURL: req.session.fromURL,
-      referenceCode: req.session.referenceCode,
-      appSessionId: req.session.appSessionId,
-      appErrorCode: req.session.appErrorCode,
-      sessionId: req.session.user?.sessionId,
-      persistentSessionId: req.session.user?.persistentSessionId,
-      userAgent: req.headers["user-agent"],
-    },
-    "User visited triage page"
-  );
-};

--- a/src/components/contact-govuk-one-login/event-service.ts
+++ b/src/components/contact-govuk-one-login/event-service.ts
@@ -1,0 +1,12 @@
+import { EventServiceInterface, Event } from "./types";
+import { SqsService } from "../../utils/types";
+import { sqsService } from "../../utils/sqs";
+
+export function eventService(sqs: SqsService = sqsService()): EventServiceInterface {
+
+  const send = function(event: Event) : void {
+    sqs.send(JSON.stringify(event));
+  };
+
+  return {send};
+}

--- a/src/components/contact-govuk-one-login/types.ts
+++ b/src/components/contact-govuk-one-login/types.ts
@@ -1,0 +1,33 @@
+export interface EventServiceInterface {
+  send: (
+    data: Event,
+  ) => void;
+}
+
+export interface Event {
+  event_name: string;
+}
+
+export interface AuditEvent extends Event {
+  timestamp: number;
+  component_id: string;
+  user: User;
+  platform: Platform;
+  extensions: Extensions;
+}
+
+export interface User {
+  session_id: string;
+  persistent_session_id: string;
+}
+
+export interface Platform {
+  user_agent: string;
+}
+
+export interface Extensions {
+  from_url: string;
+  app_session_id: string;
+  app_error_code: string;
+  reference_code: string;
+}

--- a/src/config/aws.ts
+++ b/src/config/aws.ts
@@ -6,6 +6,7 @@ import {
   getKmsKeyId,
   getLocalStackBaseUrl,
 } from "../config";
+import { SQSClientConfig } from "@aws-sdk/client-sqs";
 
 //refer to seed.yaml
 const LOCAL_KEY_ID = "ff275b92-0def-4dfc-b0f6-87c96b26c6c7";
@@ -17,6 +18,11 @@ export interface KmsConfig {
 
 export interface SnsConfig {
   awsConfig: AwsConfig;
+}
+
+export interface SqsConfig {
+  awsConfig: AwsConfig;
+  sqsClientConfig: SQSClientConfig;
 }
 
 export interface AwsConfig {
@@ -51,6 +57,31 @@ export function getSNSConfig(): SnsConfig {
 
   return {
     awsConfig: {
+      region: getAwsRegion(),
+    },
+  };
+}
+
+export function getSQSConfig(): SqsConfig {
+  if (getAppEnv() === "local") {
+    return {
+      awsConfig: { ...getLocalStackAWSConfig() },
+      sqsClientConfig: {
+        region: getAwsRegion(),
+        endpoint: "http://localstack:4566",  // NOSONAR: http used locally
+        credentials: {
+          accessKeyId: "na",
+          secretAccessKey: "na",
+        }
+      },
+    };
+  }
+
+  return {
+    awsConfig: {
+      region: getAwsRegion(),
+    },
+    sqsClientConfig: {
       region: getAwsRegion(),
     },
   };

--- a/src/utils/sqs.ts
+++ b/src/utils/sqs.ts
@@ -1,0 +1,35 @@
+import { SqsService } from "./types";
+import {
+  SendMessageCommand, SendMessageCommandOutput,
+  SendMessageRequest,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import { logger } from "./logger";
+import { getSQSConfig, SqsConfig } from "../config/aws";
+
+export function sqsService(config: SqsConfig = getSQSConfig()): SqsService {
+  const send = async function (messageBody: string): Promise<any> {
+    const { AUDIT_QUEUE_URL } = process.env;
+
+    if (AUDIT_QUEUE_URL == null) {
+      logger.error(`Environment missing value for AUDIT_QUEUE_URL, cannot send ${messageBody}.`);
+      return;
+    }
+
+    const client = new SQSClient(config.sqsClientConfig);
+
+    const message: SendMessageRequest = {
+      QueueUrl: AUDIT_QUEUE_URL,
+      MessageBody: messageBody,
+    };
+
+    try {
+      const result: SendMessageCommandOutput = await client.send(new SendMessageCommand(message));
+      logger.info(`Event sent with message id ${result.MessageId}`);
+    } catch (err) {
+      logger.error(`Failed to send message ${message.MessageBody} to SQS: ${err}`)
+    }
+  };
+
+  return { send };
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -46,6 +46,12 @@ export interface SnsService {
   ) => Promise<SNS.Types.PublishResponse>;
 }
 
+export interface SqsService {
+  send: (
+    message: string,
+  ) =>  Promise<string | undefined>
+}
+
 export interface DynamoDBService {
   getItem: (
     getCommand: DynamoDB.Types.GetItemInput

--- a/test/utils/sqs.test.ts
+++ b/test/utils/sqs.test.ts
@@ -1,0 +1,83 @@
+import { describe } from "mocha";
+import { SqsService } from "../../src/utils/types";
+import { AuditEvent } from "../../src/components/contact-govuk-one-login/types";
+import { sqsService } from "../../src/utils/sqs";
+import { SQSClient, SendMessageCommandOutput } from "@aws-sdk/client-sqs";
+import { SinonStub, stub } from "sinon";
+import { sinon } from "./test-utils";
+import { logger } from "../../src/utils/logger";
+import { expect } from "chai";
+
+describe("SQS service tests", () : void => {
+  let sqsClientStub: SinonStub;
+  let loggerSpy: sinon.SinonSpy;
+  let errorLoggerSpy: sinon.SinonSpy;
+  const expectedEvent : AuditEvent = {
+    timestamp: undefined,
+    event_name: "HOME_TRIAGE_PAGE_VISIT",
+    component_id: "HOME",
+    user: undefined,
+    platform: undefined,
+    extensions: undefined,
+  }
+
+  beforeEach((): void => {
+    sqsClientStub = stub(SQSClient.prototype, 'send');
+    loggerSpy = sinon.spy(logger, "info");
+    errorLoggerSpy = sinon.spy(logger, "error");
+    process.env.AUDIT_QUEUE_URL = "queue";
+  });
+
+  afterEach((): void => {
+    sqsClientStub.restore();
+    loggerSpy.restore();
+    errorLoggerSpy.restore();
+  });
+
+  it("can send a message to an SQS queue", async (): Promise<void> => {
+    // Arrange
+    const sqsResponse: SendMessageCommandOutput = {
+      $metadata: undefined,
+      MessageId: "message-id",
+      MD5OfMessageBody: "md5-hash"
+    }
+    sqsClientStub.returns(sqsResponse);
+    const sqs: SqsService = sqsService();
+
+    // Act
+    await sqs.send(JSON.stringify(expectedEvent));
+
+    // Assert
+    expect(sqsClientStub).to.have.calledOnce;
+    expect(loggerSpy).to.have.calledWith("Event sent with message id message-id");
+  });
+
+  it("logs event when error sending to SQS", async (): Promise<void> => {
+    // Arrange
+    const expectedError: Error = new Error("simulated error");
+    sqsClientStub.throws(expectedError);
+    const sqs: SqsService = sqsService();
+
+    // Act
+    await sqs.send(JSON.stringify(expectedEvent));
+
+    // Assert
+    expect(errorLoggerSpy).to.have.calledWith(
+      `Failed to send message ${JSON.stringify(expectedEvent)} to SQS: ${expectedError}`);
+  });
+
+  it("logs at error level if environment not set correctly", async (): Promise<void> => {
+    // Arrange
+    const sqs: SqsService = sqsService();
+    const expectedMessage: string = JSON.stringify(expectedEvent);
+    delete process.env.AUDIT_QUEUE_URL;
+
+    // Act
+    await sqs.send(expectedMessage);
+
+    // Assert
+    expect(errorLoggerSpy).to.have.calledWith(
+      `Environment missing value for AUDIT_QUEUE_URL, cannot send ${expectedMessage}.`);
+  });
+
+});


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
Send an Audit Event via SQS to TxMA.  The audit event is emitted whenever someone visits the contact page.  

### What changed

<!-- Describe the changes in detail - the "what"-->
The controller now calls out to a new EventService which sends messages via SQS.  The controller has been refactored and had some clarifying functions added.

Testing the controller has been done by creating a stub for the SQSClient.  This means the controller test knows too much about the way the EventService works but we will address this when we review the over all design with @alex9smith as a number of other areas where we can improve have been identified.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To support the requirement to record an audit event with TxMA.  The interface to TxMA is via SQS.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done -->
This has been tested in the DEV environment.  The logs from the ECS service show when the message is sent to TxMA.  The SQS queue has been reviewed and the expected message was seen.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
