### PR TITLE
OLH-1191: add guidance links to contact triage page

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -146,7 +146,7 @@ Mappings:
       WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
       SUPPORTWEBCHATCONTACT: "0"
       SUPPORTPHONECONTACT: "0"
-      SHOWCONTACTGUIDANCE: "0"
+      SHOWCONTACTGUIDANCE: "1"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
     build:
       NODEENV: "production"
@@ -167,7 +167,7 @@ Mappings:
       WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
       SUPPORTWEBCHATCONTACT: "0"
       SUPPORTPHONECONTACT: "0"
-      SHOWCONTACTGUIDANCE: "0"
+      SHOWCONTACTGUIDANCE: "1"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
     staging:
       NODEENV: "production"
@@ -230,7 +230,7 @@ Mappings:
       WEBCHATSOURCEURL: "0"
       SUPPORTWEBCHATCONTACT: "0"
       SUPPORTPHONECONTACT: "0"
-      SHOWCONTACTGUIDANCE: "0"
+      SHOWCONTACTGUIDANCE: "1"
       CONTACTEMAILSERVICEURL: "https://signin.account.gov.uk/contact-us-from-triage-page"
 
 Resources:

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -116,14 +116,17 @@
 
     {{ emailBlock | safe }}
   </section>
-  <hr class="govuk-section-break govuk-section-break--m">
-  <section>
-    {% set section4Paragraphs =  'pages.contact.section4.paragraphs' | translate({ returnObjects: true }) %}
-    <h2 class="govuk-heading-l">{{'pages.contact.section4.heading' | translate}}</h2>
-    {% for paragraph in section4Paragraphs %}
-      <p class="govuk-body">{{ paragraph | safe }}</p>
-    {% endfor %}
-  </section>
+  {% if secondaryContactMethodEnabled %}
+    {# privacy notice section should only be visible if webchat and/or phone contact are enabled #}
+    <hr class="govuk-section-break govuk-section-break--m">
+    <section>
+      {% set section4Paragraphs =  'pages.contact.section4.paragraphs' | translate({ returnObjects: true }) %}
+      <h2 class="govuk-heading-l">{{'pages.contact.section4.heading' | translate}}</h2>
+      {% for paragraph in section4Paragraphs %}
+        <p class="govuk-body">{{ paragraph | safe }}</p>
+      {% endfor %}
+    </section>
+  {% endif %}
 {% endif %}
 
 {% if contactWebchatEnabled %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -486,19 +486,19 @@
         ],
         "links": [
           {
-            "href": "",
+            "href": "https://www.gov.uk/guidance/using-the-govuk-id-check-app.cy",
             "text": "Defnyddio'r ap GOV.UK ID Check app"
           },{
-            "href": "",
+            "href": "https://www.gov.uk/guidance/proving-your-identity-with-govuk-one-login-by-answering-security-questions.cy",
             "text": "Profi eich hunaniaeth gyda GOV.UK One Login drwy ateb cwestiynau diogelwch"
           },{
-            "href": "",
+            "href": "https://www.gov.uk/guidance/changing-the-sign-in-details-for-your-govuk-one-login.cy",
             "text": "Newid y manylion mewngofnodi ar gyfer eich GOV.UK One Login"
           },{
-            "href": "",
+            "href": "https://www.gov.uk/guidance/getting-a-security-code-for-govuk-one-login.cy",
             "text": "Cael cod diogelwch ar gyfer GOV.UK One Login"
           }, {
-            "href": "",
+            "href": "https://www.gov.uk/guidance/deleting-your-govuk-one-login.cy",
             "text": "Dileu eich GOV.UK One Login"
           }
         ]

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -487,19 +487,19 @@
         ],
         "links": [
           {
-            "href": "",
+            "href": "https://www.gov.uk/guidance/using-the-govuk-id-check-app",
             "text": "Using the GOV.UK ID Check app"
           },{
-            "href": "",
-            "text": "Proving your identity with GOV.UK One Login using security questions"
+            "href": "https://www.gov.uk/guidance/proving-your-identity-with-govuk-one-login-by-answering-security-questions",
+            "text": "Proving your identity with GOV.UK One Login by answering security questions"
           },{
-            "href": "",
-            "text": "Change the sign in details for your GOV.UK One Login"
+            "href": "https://www.gov.uk/guidance/changing-the-sign-in-details-for-your-govuk-one-login",
+            "text": "Changing the sign in details for your GOV.UK One Login"
           },{
-            "href": "",
+            "href": "https://www.gov.uk/guidance/getting-a-security-code-for-govuk-one-login",
             "text": "Getting a security code for GOV.UK One Login"
           }, {
-            "href": "",
+            "href": "https://www.gov.uk/guidance/deleting-your-govuk-one-login",
             "text": "Deleting your GOV.UK One Login"
           }
         ]


### PR DESCRIPTION
### What changed
Adds links to the newly published Whitehall guidance to the new contact triage page.
Enables the guidance section in all environments. 
Ensures that privacy notice is only displayed when webchat and/or phone are enabled.

<img width="1028" alt="Screenshot 2023-10-26 at 15 01 40" src="https://github.com/alphagov/di-account-management-frontend/assets/7116819/dd9ec77a-ed78-4700-99bb-247b972ed20a">

https://govukverify.atlassian.net/browse/OLH-1191 
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The contact triage page went live yesterday with contact form only and without the guidance links, as guidance had not been published yet.
Now that guidance has been published, this section can be switched on. 

<!-- Describe the reason these changes were made - the "why" -->

## Testing
- checked that the English language links all lead to the English language versions of the Whitehall guidance
- checked that the Welsh links lead to the Welsh version of the guidance
- checked that the privacy notice section only displays when phone or webchat are enabled

<!-- Provide a summary of any manual testing you've done -->

## How to review
Perhaps double check all the above
<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
