### PR TITLE
OLH-1154 - Add a link to support from the home.account footer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -58,6 +58,8 @@ import { redirectsRouter } from "./components/redirects/redirects-routes";
 import { contactRouter } from "./components/contact-govuk-one-login/contact-govuk-one-login-routes";
 import { getSessionStore } from "./utils/session-store";
 import { webchatRouter } from "./components/webchat-demo/webchat-demo-routes";
+import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-us-links-middleware";
+
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -71,6 +73,7 @@ async function createApp(): Promise<express.Application> {
   app.enable("trust proxy");
 
   app.use(loggerMiddleware);
+  app.use(outboundContactUsLinksMiddleware);
 
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -93,6 +93,11 @@
                 {
                     href: authFrontEndUrl + "/privacy-notice",
                     text: 'general.footer.privacy.linkText' | translate
+                },
+                {
+                    href: contactUsLinkUrl,
+                    attributes: {target: "_blank"},
+                    text: 'general.footer.support.linkText' | translate
                 }
             ]
         },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -80,6 +80,9 @@
         "pageTitle": "Hysbysiad preifatrwydd",
         "linkText": "Hysbysiad preifatrwydd"
       },
+      "support": {
+        "linkText": "Cefnogaeth (agor mewn tab newydd)"
+      },
       "copyright": {
         "linkText": "© Hawlfraint y goron"
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -80,6 +80,9 @@
         "pageTitle": "Privacy notice",
         "linkText": "Privacy notice"
       },
+      "support": {
+        "linkText": "Support (opens in new tab)"
+      },
       "copyright": {
         "linkText": "© Crown copyright"
       },

--- a/src/middleware/outbound-contact-us-links-middleware.ts
+++ b/src/middleware/outbound-contact-us-links-middleware.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from "express";
+import { PATH_DATA } from "../app.constants";
+
+export function buildUrlFromRequest(req: Request): string {
+  return `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+}
+
+export function appendFromUrlWhenTriagePageUrl(
+  contactUsLinkUrl: string,
+  fromUrl: string
+): string {
+  const triagePageUrlRegEx = /contact-gov-uk-one-login/;
+
+  if (triagePageUrlRegEx.test(contactUsLinkUrl)) {
+    const encodedFromUrl = encodeURIComponent(fromUrl);
+
+    contactUsLinkUrl = `${contactUsLinkUrl}?fromURL=${encodedFromUrl}`;
+  }
+
+  return contactUsLinkUrl;
+}
+
+export function outboundContactUsLinksMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  let contactUsLinkUrl = `${req.protocol}://${req.get("host")}${PATH_DATA.CONTACT.url}`;
+  const fromUrl = buildUrlFromRequest(req);
+
+  contactUsLinkUrl = appendFromUrlWhenTriagePageUrl(contactUsLinkUrl, fromUrl);
+
+  res.locals.contactUsLinkUrl = contactUsLinkUrl;
+  next();
+}

--- a/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
+++ b/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
@@ -1,0 +1,122 @@
+import { describe } from "mocha";
+import { sinon } from "../../utils/test-utils";
+import chai, { expect } from "chai";
+import { Request, Response } from "express";
+import sinonChai from "sinon-chai";
+import {
+  appendFromUrlWhenTriagePageUrl,
+  buildUrlFromRequest,
+  outboundContactUsLinksMiddleware,
+} from "../../../src/middleware/outbound-contact-us-links-middleware";
+
+chai.use(sinonChai);
+
+describe("Middleware", () => {
+  describe("outboundContactUsLinksMiddleware", () => {
+    let req: Request;
+    let res: Response;
+    let next: sinon.SinonSpy;
+
+    beforeEach(() => {
+      req = {
+        protocol: "https",
+        headers: {
+          host: "home.account.gov.uk",
+        },
+        originalUrl: "/contact-gov-uk-one-login",
+        cookies: {},
+        session: {
+          id: "session-id",
+          destroy: sinon.stub().callsArg(0),
+        },
+        log: {
+          error: sinon.stub(),
+          info: sinon.stub(),
+        },
+        get: function (headerName: string) {
+          if (headerName === "Referrer") {
+            return this.headers["referer"] || this.headers["referrer"];
+          }
+          if (headerName === "host") {
+            return "home.account.gov.uk";
+          }
+        },
+      } as any;
+      res = {
+        locals: {},
+        status: sinon.stub().returns({
+          json: sinon.stub(),
+        }),
+      } as any;
+      next = sinon.spy();
+    });
+
+    it("should call next", () => {
+      outboundContactUsLinksMiddleware(req, res, next);
+      expect(req.session.destroy).to.not.have.been.called;
+      expect(res.status).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
+    });
+
+    it("should set `res.locals.contactUsLinkUrl`", () => {
+      expect(res.locals).to.not.have.property("contactUsLinkUrl");
+      outboundContactUsLinksMiddleware(req, res, next);
+      expect(res.locals).to.have.property("contactUsLinkUrl");
+    });
+    it("should set `res.locals.contactUsLinkUrl correct value`", () => {
+      expect(res.locals).to.not.have.property("contactUsLinkUrl");
+      outboundContactUsLinksMiddleware(req, res, next);
+      expect(res.locals).to.have.property("contactUsLinkUrl");
+      expect(res.locals.contactUsLinkUrl).to.equal("https://home.account.gov.uk/contact-gov-uk-one-login?" +
+        "fromURL=https%3A%2F%2Fhome.account.gov.uk%2Fcontact-gov-uk-one-login");
+    });
+  });
+
+  describe("buildFromUrl", () => {
+    let req: Request;
+
+    beforeEach(() => {
+      req = {
+        protocol: "https",
+        headers: {
+          host: "home.account.gov.uk",
+        },
+        originalUrl: "/contact-gov-uk-one-login",
+        get: function (headerName: string) {
+          return this.headers[headerName];
+        },
+      } as any;
+    });
+
+    it("should build the fromUrl as expected", () => {
+      const builtUrl = buildUrlFromRequest(req),
+        expectedUrl = "https://home.account.gov.uk/contact-gov-uk-one-login";
+
+      expect(builtUrl).to.equal(expectedUrl);
+      buildUrlFromRequest(req);
+    });
+  });
+
+  describe("appendFromUrlWhenTriagePageUrl", () => {
+    it("should append when there's a match", () => {
+      const matchingUrl =
+          "https://home.account.gov.uk/contact-gov-uk-one-login",
+        fromUrl = "https://signin.account.gov.uk/enter-password";
+
+      const result = appendFromUrlWhenTriagePageUrl(matchingUrl, fromUrl);
+
+      expect(result).to.equal(
+        `${matchingUrl}?fromURL=${encodeURIComponent(fromUrl)}`
+      );
+    });
+
+    it("should not append when there isn't a match", () => {
+      const nonMatchingUrl = "https://signin.account.gov.uk/contact-us",
+        fromUrl = "https://signin.account.gov.uk/enter-password";
+
+      const result = appendFromUrlWhenTriagePageUrl(nonMatchingUrl, fromUrl);
+
+      expect(result).to.not.contain(encodeURIComponent(fromUrl));
+    });
+  });
+});

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -88,6 +88,7 @@ describe("string-helpers", () => {
       expect(isValidUrl("qwerty")).to.be.false;
       expect(isValidUrl("qwerty.gov.&^")).to.be.false;
       expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
+      expect(isValidUrl("http://localhost:6001")).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Proposed changes
OLH-1154 - Add a link to support from the home.account footer
User Story: https://govukverify.atlassian.net/browse/OLH-1154

### What changed
Change in English and Welsh translation.js to accommodate internationalisation.
Add new element in Nunjuck to include the support link
Images of the before and after can be seen in https://govukverify.atlassian.net/browse/OLH-1154


### Why did it change
So users who are signed in and who need help have somewhere to go.


### Related links



## Checklists


### Environment variables or secrets
N/A

## Testing
I viewed the home account in English and Welsh translation and verified new link is added successfully and clickthrough goes to the correct page.

Deployed to Dev environment and demoed with Ben Mortimer (Product Owner).

## How to review
The new support link in the footer should be clicked, open in a new tab and ensure it goes to the one login contact page.
Verify the URL contains the fromUrl parameter
Verify click through to contact form has the fromUrl appended

To view the home.account in welsh vs English
add ?lng=cy to the url for Welsh
then ?lng=en to switch back


Please note this is a duplicate of the previously approved branch OLH-1154, recreated as a new commit due to unsigned commit in the history.
