### PR TITLE
OLH-1200: Get session IDs from locals

### DIFF
--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -13,7 +13,7 @@ import { eventService } from "./event-service";
 import { AuditEvent, Extensions, Platform, User } from "./types";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
-const MISSING_SESSION_VALUE_SPECIAL_CASE : string = "";
+const MISSING_SESSION_VALUE_SPECIAL_CASE: string = "";
 
 export function contactGet(req: Request, res: Response): void {
   updateSessionFromQueryParams(req.session, req.query);
@@ -27,23 +27,34 @@ const updateSessionFromQueryParams = (session: any, queryParams: any): void => {
   if (isValidUrl(queryParams.fromURL as string)) {
     session.fromURL = queryParams.fromURL;
   } else {
-    logger.error("fromURL in request query for contact-govuk-one-login page did not pass validation");
+    logger.error(
+      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+    );
   }
 
-  copySafeQueryParamToSession(session, queryParams, 'theme');
-  copySafeQueryParamToSession(session, queryParams, 'appSessionId');
-  copySafeQueryParamToSession(session, queryParams, 'appErrorCode');
+  copySafeQueryParamToSession(session, queryParams, "theme");
+  copySafeQueryParamToSession(session, queryParams, "appSessionId");
+  copySafeQueryParamToSession(session, queryParams, "appErrorCode");
 
   if (!session.referenceCode) {
     session.referenceCode = generateReferenceCode();
   }
-}
+};
 
-const copySafeQueryParamToSession = (session: any, queryParams: any, paramName: string) => {
-  if (queryParams[paramName] && isSafeString(queryParams[paramName] as string)) {
+const copySafeQueryParamToSession = (
+  session: any,
+  queryParams: any,
+  paramName: string
+) => {
+  if (
+    queryParams[paramName] &&
+    isSafeString(queryParams[paramName] as string)
+  ) {
     session[paramName] = queryParams[paramName];
   } else {
-    logger.error(`${paramName} in request query for contact-govuk-one-login page did not pass validation`);
+    logger.error(
+      `${paramName} in request query for contact-govuk-one-login page did not pass validation`
+    );
   }
 };
 
@@ -123,11 +134,17 @@ const buildContactEmailServiceUrl = (req: Request): URL => {
   }
 
   if (req.session.appSessionId) {
-    contactEmailServiceUrl.searchParams.append("appSessionId", req.session.appSessionId);
+    contactEmailServiceUrl.searchParams.append(
+      "appSessionId",
+      req.session.appSessionId
+    );
   }
 
   if (req.session.appErrorCode) {
-    contactEmailServiceUrl.searchParams.append("appErrorCode", req.session.appErrorCode);
+    contactEmailServiceUrl.searchParams.append(
+      "appErrorCode",
+      req.session.appErrorCode
+    );
   }
 
   return contactEmailServiceUrl;
@@ -177,4 +194,3 @@ const render = (req: Request, res: Response): void => {
 
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);
 };
-

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -17,7 +17,7 @@ const MISSING_SESSION_VALUE_SPECIAL_CASE : string = "";
 
 export function contactGet(req: Request, res: Response): void {
   updateSessionFromQueryParams(req.session, req.query);
-  const audit_event = buildAuditEvent(req);
+  const audit_event = buildAuditEvent(req, res);
   logUserVisitsContactPage(audit_event);
   sendUserVisitsContactPageAuditEvent(audit_event);
   render(req, res);
@@ -47,20 +47,20 @@ const copySafeQueryParamToSession = (session: any, queryParams: any, paramName: 
   }
 };
 
-const buildAuditEvent = (req: Request): AuditEvent => {
+const buildAuditEvent = (req: Request, res: Response): AuditEvent => {
   const session: any = req.session;
   let sessionId: string;
 
-  if (userHasSignedIntoHomeRelyingParty(session)) {
-    sessionId = session.user.sessionId;
+  if (userHasSignedIntoHomeRelyingParty(res)) {
+    sessionId = res.locals.sessionId;
   } else {
     sessionId = MISSING_SESSION_VALUE_SPECIAL_CASE;
   }
 
   let persistentSessionId: string;
 
-  if (session.user?.persistentSessionId) {
-    persistentSessionId = session.user.persistentSessionId;
+  if (res.locals.persistentSessionId) {
+    persistentSessionId = res.locals.persistentSessionId;
   } else {
     persistentSessionId = MISSING_SESSION_VALUE_SPECIAL_CASE;
   }
@@ -97,15 +97,15 @@ const buildAuditEvent = (req: Request): AuditEvent => {
     platform: platform,
     extensions: extensions,
   };
-}
+};
 
-const userHasSignedIntoHomeRelyingParty = (session: any): boolean => {
-  return !!session.user?.sessionId;
-}
+const userHasSignedIntoHomeRelyingParty = (res: Response): boolean => {
+  return !!res.locals?.sessionId;
+};
 
 const userHasComeFromTheApp = (session: any): boolean => {
   return !!session.appSessionId;
-}
+};
 
 const buildContactEmailServiceUrl = (req: Request): URL => {
   const contactEmailServiceUrl: URL = new URL(getContactEmailServiceUrl());

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -43,7 +43,10 @@ describe("Contact GOV.UK One Login controller", () => {
     res = {
       render: sandbox.fake(),
       redirect: sandbox.fake(),
-      locals: {},
+      locals: {
+        sessionId: "sessionId",
+        persistentSessionId: "persistentSessionId",
+      },
       status: sandbox.fake(),
     };
 

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -277,7 +277,7 @@ describe("Contact GOV.UK One Login controller", () => {
           isAuthenticated: true,
         },
       };
-      req.cookies.lo = 'true';
+      req.cookies.lo = "true";
       contactGet(req as Request, res as Response);
       expect(res.render).to.have.calledWith(CONTACT_ONE_LOGIN_TEMPLATE, {
         contactWebchatEnabled: true,
@@ -335,12 +335,12 @@ describe("Contact GOV.UK One Login controller", () => {
       const expectedPersistentSessionId = "persistentSessionId";
       const expectedTimestamp = 1111;
 
-      sqsClientStub = stub(SQSClient.prototype, 'send');
+      sqsClientStub = stub(SQSClient.prototype, "send");
       const sqsResponse: SendMessageCommandOutput = {
         $metadata: undefined,
         MessageId: "message-id",
-        MD5OfMessageBody: "md5-hash"
-      }
+        MD5OfMessageBody: "md5-hash",
+      };
       process.env.AUDIT_QUEUE_URL = "queue";
       sqsClientStub.returns(sqsResponse);
 
@@ -357,7 +357,7 @@ describe("Contact GOV.UK One Login controller", () => {
         referenceCode: "reference-code",
       };
 
-      req.query.fromURL = 'https://gov.uk/ogd';
+      req.query.fromURL = "https://gov.uk/ogd";
       req.query.appErrorCode = "app-error-code";
       req.query.appSessionId = "app-session-id";
 
@@ -369,7 +369,6 @@ describe("Contact GOV.UK One Login controller", () => {
 
       // Tidy up
       sqsClientStub.restore();
-    })
-
+    });
   });
 });


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Switch to getting the session IDs from the response locals instead of the session data.

This PR also includes some automated linting changes. I've put these in a separate commit to make it easier to see the change of logic.

### Why did it change

The session ID and persistent session ID are stored in the response locals, not the user's session data.

This means that we were always sending an empty string for these values in the audit and log events.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've run the app locally and verified I can see the session IDs in the log events: 

```
account-management-frontend  | [Node] [14:42:54.456] INFO (di-auth-account-management/662): User visited triage page
account-management-frontend  | [Node]     referenceCode: "905380"
account-management-frontend  | [Node]     appSessionId: ""
account-management-frontend  | [Node]     sessionId: "123"
account-management-frontend  | [Node]     persistentSessionId: "persistentSessionId"
account-management-frontend  | [Node]     userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
```
## How to review

These session IDs are pulled from cookies set at the `account.gov.uk` level during the sign in journey. Our stub OIDC server doesn't set these cookies so this won't work locally, in dev or in build without manually setting the cookies.

To see this running locally, run the app and go to the contact triage page. Then in your browser's dev tools set the following cookies:

| Name | Value |
| -- | -- |
| `gs` | `sessionId.clientSessionId`|
|`di-persistent-session-id` | `persistentSessionId`|

Then when you reload the page you'll see the IDs in the container logs.