### PR TITLE
OLH-1122 - add missing timestamp to audit event.

### DIFF
--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -101,7 +101,7 @@ const buildAuditEvent = (req: Request, res: Response): AuditEvent => {
   };
 
   return {
-    timestamp: req.session.timestamp,
+    timestamp: Date.now(),
     event_name: "HOME_TRIAGE_PAGE_VISIT",
     component_id: "HOME",
     user: user,

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -8,6 +8,8 @@ import * as reference from "../../../utils/referenceCode";
 import { SinonStub, stub } from "sinon";
 import { SendMessageCommandOutput, SQSClient } from "@aws-sdk/client-sqs";
 import { I18NextRequest } from "i18next-http-middleware";
+import { AuditEvent } from "../types";
+import { SendMessageCommandInput } from "@aws-sdk/client-sqs/dist-types/commands/SendMessageCommand";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 const MOCK_REFERENCE_CODE = "123456";
@@ -333,7 +335,12 @@ describe("Contact GOV.UK One Login controller", () => {
       // Arrange
       const expectedSessionId = "sessionId";
       const expectedPersistentSessionId = "persistentSessionId";
-      const expectedTimestamp = 1111;
+      const sessionFromURL = "from-url";
+      const expectedAppErrorCode = "app-error-code";
+      const expectedAppSessionId = "app-session-id";
+      const expectedReferenceCode = "reference-code";
+      const expectedFromURL = "https://gov.uk/ogd";
+      const expectedUserAgent = "expectedUserAgent";
 
       sqsClientStub = stub(SQSClient.prototype, "send");
       const sqsResponse: SendMessageCommandOutput = {
@@ -350,22 +357,36 @@ describe("Contact GOV.UK One Login controller", () => {
           sessionId: expectedSessionId,
           persistentSessionId: expectedPersistentSessionId,
         },
-        timestamp: expectedTimestamp,
-        fromURL: "fromUrl",
-        appErrorCode: "app-error-code",
-        appSessionId: "app-session-id",
-        referenceCode: "reference-code",
+        fromURL: sessionFromURL,
+        appErrorCode: expectedAppErrorCode,
+        appSessionId: expectedAppSessionId,
+        referenceCode: expectedReferenceCode,
       };
 
-      req.query.fromURL = "https://gov.uk/ogd";
-      req.query.appErrorCode = "app-error-code";
-      req.query.appSessionId = "app-session-id";
+      req.query.fromURL = expectedFromURL;
+      req.query.appErrorCode = expectedAppErrorCode;
+      req.query.appSessionId = expectedAppSessionId;
+      req.headers["user-agent"] = expectedUserAgent;
+
+      res.locals.sessionId = expectedSessionId;
+      res.locals.persistent_session_id = expectedPersistentSessionId;
 
       // Act
       contactGet(req as Request, res as Response);
 
       // Assert
       expect(sqsClientStub.called);
+      const publishedEvent = JSON.parse(sqsClientStub.getCall(0).firstArg.input.MessageBody) as AuditEvent;
+      expect(publishedEvent.event_name).to.equal("HOME_TRIAGE_PAGE_VISIT");
+      expect(publishedEvent.timestamp);
+      expect(publishedEvent.component_id).to.equal("HOME");
+      expect(publishedEvent.user.session_id).to.equal(expectedSessionId);
+      expect(publishedEvent.user.persistent_session_id).to.equal(expectedPersistentSessionId);
+      expect(publishedEvent.platform.user_agent).to.equal("expectedUserAgent");
+      expect(publishedEvent.extensions.app_error_code).to.equal(expectedAppErrorCode);
+      expect(publishedEvent.extensions.app_session_id).to.equal(expectedAppSessionId);
+      expect(publishedEvent.extensions.reference_code).to.equal(expectedReferenceCode);
+      expect(publishedEvent.extensions.from_url).to.equal(expectedFromURL);
 
       // Tidy up
       sqsClientStub.restore();

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -9,7 +9,6 @@ import { SinonStub, stub } from "sinon";
 import { SendMessageCommandOutput, SQSClient } from "@aws-sdk/client-sqs";
 import { I18NextRequest } from "i18next-http-middleware";
 import { AuditEvent } from "../types";
-import { SendMessageCommandInput } from "@aws-sdk/client-sqs/dist-types/commands/SendMessageCommand";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 const MOCK_REFERENCE_CODE = "123456";


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
Add timestamp to audit event.

### What changed
The audit event being sent to TxMA now creates a timestamp rather than trying to retrieve one from the session.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The timestamp is a mandatory field that causes TxMA to send event to the DLQ if missing.  The session did not contain a timestamp so we have changed to generating one at the time the event is created.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

## Testing

<!-- Provide a summary of any manual testing you've done -->

I tested in DEV.  I could see the new audit event had a timestamp.  I did not see the event on the DLQ.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
