### PR TITLE
OLH-1184 - Try strict-dynamic directive for the webchat

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -113,8 +113,8 @@
 
 {% block bodyEnd %}
     {% block scripts %}{% endblock %}
-    <script type="text/javascript" src="/public/scripts/application.js"></script>
-    <script type="text/javascript" src="/public/scripts/all.js"></script>
+    <script type="text/javascript" src="/public/scripts/application.js" nonce='{{scriptNonce}}'></script>
+    <script type="text/javascript" src="/public/scripts/all.js" nonce='{{scriptNonce}}'></script>
     <script type="text/javascript" nonce='{{scriptNonce}}'>
         window
             .GOVSignIn

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -60,6 +60,7 @@ const render = (req: Request, res: Response): void => {
     currentUrl: originalUrl,
     baseUrl,
     language,
+    nonce: res.locals.scriptNonce,
   };
 
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -133,7 +133,8 @@
 {% if contactWebchatEnabled %}
   <script id="smartagent" type="module" defer 
     src="{{ webchatSource }}" 
-    data-company="hgsgds" data-brand="hgsgds">
+    data-company="hgsgds" data-brand="hgsgds"
+    nonce="{{ nonce }}">
   </script>
   <script type="text/javascript" nonce='{{scriptNonce}}'>
     var launchWebchatButton = document.querySelector("[data-launch-webchat]");

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -12,6 +12,7 @@ import { AuditEvent } from "../../../services/types";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 const MOCK_REFERENCE_CODE = "123456";
+const MOCK_NONCE = "abcdef";
 
 describe("Contact GOV.UK One Login controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -48,6 +49,7 @@ describe("Contact GOV.UK One Login controller", () => {
       locals: {
         sessionId: "sessionId",
         persistentSessionId: "persistentSessionId",
+        scriptNonce: MOCK_NONCE,
       },
       status: sandbox.fake(),
     };
@@ -99,6 +101,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
     });
 
@@ -129,6 +132,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
     });
 
@@ -162,6 +166,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
       // query data should be saved into session
       expect(req.session.queryParameters.fromURL).to.equal(fromURL);
@@ -200,6 +205,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
       // invalid query data should not be saved into session
       expect(req.session.queryParameters.fromURL).to.equal(validUrl);
@@ -230,6 +236,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
       expect(loggerSpy).to.have.calledWith(
         {
@@ -264,6 +271,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
     });
 
@@ -286,6 +294,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
     });
 
@@ -309,6 +318,7 @@ describe("Contact GOV.UK One Login controller", () => {
         currentUrl: baseUrl,
         baseUrl,
         language: "en",
+        nonce: MOCK_NONCE,
       });
     });
 

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -56,7 +56,7 @@ export const webchatHelmetConfiguration: Parameters<typeof helmet>[0] = {
         "https://www.google-analytics.com",
         "https://ssl.google-analytics.com",
         "https://*.smartagent.app",
-        "'unsafe-inline'",
+        "'strict-dynamic'",
       ],
       scriptSrcAttr: ["'self'", "'unsafe-inline'"],
       imgSrc: [
@@ -64,6 +64,7 @@ export const webchatHelmetConfiguration: Parameters<typeof helmet>[0] = {
         "data:",
         "https://www.googletagmanager.com",
         "https://www.google-analytics.com",
+        "https://*.s3.eu-west-2.amazonaws.com"
       ],
       objectSrc: ["'none'"],
       connectSrc: [


### PR DESCRIPTION
## Proposed changes

[OLH-1184] - Try strict-dynamic directive for the web chat 
Change our  Content Security Policy (CSP) to **_strict dynamic_** to prevent cross site scripting. 
This change will NOT support older browser versions that does not support strict dynamic. As that will mean the site is still susceptible to CSS attack with older versions.
JIRA Ticket: https://govukverify.atlassian.net/browse/OLH-1184

### What changed
- Make nonce available to frontend
- Include a nonce in the <script> tags that load the initial webchat script
- Switch the webchat from using the ‘unsafe-inline' Content Security Policy (CSP) directive for scripts to 'strict-dynamic'.
- Test to ensure all required scripts are still loading  even with **_strict dynamic_** configured

### Why did it change
Using 'unsafe-inline' for scripts in the CSP is an unacceptable security risk

### Related links
Configuration Doc: https://content-security-policy.com/strict-dynamic/

## Checklists
Test in higher environment to ensure DI- one login home is still able to load all existing scripts and pages function correctly

Please see below sample of the CSP in the dev enironment, was able to use webchat, send messsages and closes fine, No CSP related error in the console

`default-src 'self';style-src 'self' https://*.smartagent.app 'unsafe-inline';script-src 'self' 'nonce-0d423d3e0184529a3fad04c4e8ae34b7' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://*.smartagent.app 'strict-dynamic';script-src-attr 'self' 'unsafe-inline';img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://*.s3.eu-west-2.amazonaws.com;object-src 'none';connect-src 'self' https://www.google-analytics.com https://*.smartagent.app;form-action 'self' https://*.account.gov.uk;media-src 'self' https://*.s3.eu-west-2.amazonaws.com;frame-src 'self' https://*.smartagent.app;base-uri 'self';font-src 'self' https: data:;frame-ancestors 'self';upgrade-insecure-requests`



### Environment variables or secrets
N/A

## Testing

- Open: https://home.dev.account.gov.uk/contact-gov-uk-one-login
- Open Developer Console on the page
- Check console and ensure no error exist with loading required javascript e.g. application.js, all.js.
- Verify you can initiate web chat
- Verify strict domain by checking the response header for the CSP. It will be titled "content-security-policy

## How to review

[OLH-1184]: https://govukverify.atlassian.net/browse/OLH-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ