### PR TITLE
OLH-1123 - Return a 403 error when a user fails to sign in

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -150,3 +150,7 @@ export const ENVIRONMENT_NAME = {
   PROD: "production",
   DEV: "development",
 };
+
+export const OIDC_ERRORS = {
+  ACCESS_DENIED: "access_denied",
+};

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { CallbackParamsType, TokenSet, UserinfoResponse } from "openid-client";
-import { PATH_DATA, VECTORS_OF_TRUST } from "../../app.constants";
+import { HTTP_STATUS_CODES, OIDC_ERRORS, PATH_DATA, VECTORS_OF_TRUST } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { ClientAssertionServiceInterface } from "../../utils/types";
 import { clientAssertionGenerator } from "../../utils/oidc";
@@ -47,6 +47,9 @@ export function oidcAuthCallbackGet(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const queryParams: CallbackParamsType = req.oidc.callbackParams(req);
+    if(queryParams.error === OIDC_ERRORS.ACCESS_DENIED) {
+      res.status(HTTP_STATUS_CODES.FORBIDDEN);
+    }
     const clientAssertion = await service.generateAssertionJwt(
       req.oidc.metadata.client_id,
       req.oidc.issuer.metadata.token_endpoint

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -47,7 +47,7 @@ export function oidcAuthCallbackGet(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const queryParams: CallbackParamsType = req.oidc.callbackParams(req);
-    if(queryParams?.error === OIDC_ERRORS.ACCESS_DENIED) {
+    if (queryParams?.error === OIDC_ERRORS.ACCESS_DENIED) {
       res.status(HTTP_STATUS_CODES.FORBIDDEN);
     }
     const clientAssertion = await service.generateAssertionJwt(

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -47,7 +47,7 @@ export function oidcAuthCallbackGet(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const queryParams: CallbackParamsType = req.oidc.callbackParams(req);
-    if(queryParams.error === OIDC_ERRORS.ACCESS_DENIED) {
+    if(queryParams?.error === OIDC_ERRORS.ACCESS_DENIED) {
       res.status(HTTP_STATUS_CODES.FORBIDDEN);
     }
     const clientAssertion = await service.generateAssertionJwt(

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -4,7 +4,7 @@ import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 import { oidcAuthCallbackGet } from "../call-back-controller";
-import { PATH_DATA, VECTORS_OF_TRUST } from "../../../app.constants";
+import { HTTP_STATUS_CODES, PATH_DATA, VECTORS_OF_TRUST } from "../../../app.constants";
 import { ClientAssertionServiceInterface } from "../../../utils/types";
 
 describe("callback controller", () => {
@@ -107,6 +107,31 @@ describe("callback controller", () => {
       await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_DATA.START.url);
+    });
+    it("should throw 500 error when access denied error occured", async () => {
+      req.params = {
+        error:'access_denied',
+          state:'m0H_2VvrhKR0qA'
+      };
+      req.oidc = {
+        callbackParams: ''
+      };
+      const fakeService: ClientAssertionServiceInterface = {
+        generateAssertionJwt: sandbox.fake.returns("testassert"),
+      };
+
+      await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_DATA.YOUR_SERVICES.url);
+    });
+
+    it("response status code should be 403 when access denied error occurs", async () => {
+      req.oidc.callbackParams = sandbox.fake.returns({"error":"access_denied","state":"m0H_2VvrhKR0qA"});
+      const fakeService: ClientAssertionServiceInterface = {
+        generateAssertionJwt: sandbox.fake.returns("testassert"),
+      };
+      await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
+      expect(res.status).to.have.calledWith(HTTP_STATUS_CODES.FORBIDDEN);
     });
   });
 });

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -41,6 +41,7 @@ describe("callback controller", () => {
     };
     res = {
       render: sandbox.fake(),
+      status: sandbox.fake(),
       redirect: sandbox.fake(),
       cookie: sandbox.fake(),
       locals: {},
@@ -107,22 +108,6 @@ describe("callback controller", () => {
       await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_DATA.START.url);
-    });
-    it("should throw 500 error when access denied error occured", async () => {
-      req.params = {
-        error:'access_denied',
-          state:'m0H_2VvrhKR0qA'
-      };
-      req.oidc = {
-        callbackParams: ''
-      };
-      const fakeService: ClientAssertionServiceInterface = {
-        generateAssertionJwt: sandbox.fake.returns("testassert"),
-      };
-
-      await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
-
-      expect(res.redirect).to.have.calledWith(PATH_DATA.YOUR_SERVICES.url);
     });
 
     it("response status code should be 403 when access denied error occurs", async () => {


### PR DESCRIPTION
## Proposed changes
When an access denied error is sent from auth-frontend, rather than handling the error, we let it propagate which triggers another error and causes a 500 error to be thrown rather than the workflow for handling access denied errors.
JIRA Ticket: https://govukverify.atlassian.net/browse/OLH-1123

### What changed
In auth-callback controller, we check the query params for access denied error, if founds, we will then update the response status to 403.  This triggers the internal-error-handler and redirects to the configured session expired page.

Also this will stop the triggering of the [CloudWatch Alarm | account-mgmt-frontend-ApiGateway5xxStatusAlarm | eu-west-2 | Account: 026991849909](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#alarm:name=account-mgmt-frontend-ApiGateway5xxStatusAlarm) in https://gds.slack.com/archives/C04D3SQNJ4B


### Why did it change

So that the Home team handles access denied errors correctly and not throw error 500 incorrectly.


### Related links
https://govukverify.atlassian.net/browse/OLH-1123
https://gds.slack.com/archives/C04D3SQNJ4B


## Checklists

### Environment variables or secrets
N/A


## Testing
- Retrieved the access denied logs in production and examined the request/response and stack trace
- In Local environment, trigger the same request as per the prod logs in local environment and dev environment
- Observe the behaviour is as per expected

## How to review
Code changes are minimal and self descriptive in the PR
To test, please use: http://home.dev.account.gov.uk/auth/callback?error=access_denied&state=m0H_2VvrhKR0qA
