### PR TITLE
OLH-1209: "Use webchat" conditional display

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -345,4 +345,9 @@ $nav-active-border-thickness: 5px;
   @include govuk-link-common;
   @include govuk-link-style-default;
   @include govuk-link-print-friendly;
+
+  &[hidden] {
+    display: inline-block;
+    visibility: hidden;
+  }
 }

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -107,7 +107,7 @@
         {% for paragraph in webchatParagraphs %}
           <p class="govuk-body">{{ paragraph | safe  }}</p>
         {% endfor %}
-        <p class="govuk-body"><button type="button" class="launch-webchat-link" data-launch-webchat>{{ 'pages.contact.section3.webchat.linkText' | translate }}</button></p>
+        <p class="govuk-body"><button type="button" class="launch-webchat-link" data-launch-webchat hidden>{{ 'pages.contact.section3.webchat.linkText' | translate }}</button></p>
       </section>
     {% endif %}
 
@@ -137,11 +137,35 @@
   </script>
   <script type="text/javascript" nonce='{{scriptNonce}}'>
     var launchWebchatButton = document.querySelector("[data-launch-webchat]");
+
     launchWebchatButton.addEventListener("click", function() {
       if (window._sa) {
         window._sa.openChat();
       }
-    })
+    });
+
+    function waitForSaEvents(){
+      // if saEvents does not exist, chat has not loaded yet
+      if(typeof window.saEvents !== "undefined"){
+        window.saEvents.subscribe(function (event) {
+          if (event.type === "CHAT_LOADED") {
+            // as soon as a CHAT_LOADED event is received from the webchat, make the "Use webchat" toggle visible and stop listening for chat events
+            launchWebchatButton.removeAttribute('hidden');
+            clearInterval(webchatInterval);
+            clearTimeout(cancelInterval);
+          }
+        });
+      }
+    }
+
+    // the webchat script injects other scripts and assets into the page
+    // therefore the "saEvents" object is not immediately available to subscribe to
+    // this checks whether "saEvents" is available every 200ms 
+    var webchatInterval = setInterval(waitForSaEvents, 200);
+    var cancelInterval = setTimeout(function(){
+      // if webchat events still unavailable after 10s, clear the interval
+      clearInterval(webchatInterval);
+    }, 10000)
   </script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Display the "Use webchat" link only once Webchat is actually available
to use.


<!-- Describe the changes in detail - the "what"-->

### Why did it change

There are a number of things that could potentially go wrong: poor
network conditions meaning that the chat is slow to load, JS disabled in
the browser, or a breaking error with the chat preventing it from
loading for instance. In all of these instances, displaying the "Use
webchat" link unconditionally could result in users attempting to
interact with it and having a frustrating experience when clicking it
does not produce any outcome.

To display the link conditionally, I listened for the `CHAT_LOADED` event
dispatched by the webchat script. Seeing as the webchat script loads
somewhat asynchronously however, that means that the `SaEvents` object
is not immediately available to subscribe to. The way I got around this
is I set an interval checking for the existence of the object. If the
object still does not exist after 10 seconds of trying, break out of the
loop.

To hide the "Use webchat" link button, I used `visibility: hidden` as we
wanted the layout to remain unchanged to prevent a layout shift when the
element becomes visible.
I used the `hidden` HTML attribute as this hides the element and indicates
it is not yet relevant, but `aria-hidden` would have had a similar effect.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Tested in browser disabling cache and simulating poor network conditions.

<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
