### PR TITLE
OLH-1190: Don't export logs to Splunk in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -119,6 +119,12 @@ Conditions:
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, dev]
 
+  ExportLogsToSplunk:
+    Fn::Or:
+      - !Equals [!Ref Environment, staging]
+      - !Equals [!Ref Environment, integration]
+      - !Equals [!Ref Environment, production]
+
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -678,6 +684,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   TaskLogGroupCSLSSubscription:
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1201,6 +1208,7 @@ Resources:
           Value: !Ref SourceTagValue
 
   ApiGatewayAccessLogGroupCSLSSubscription:
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Set up a new [condition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html) to track which environments we want to send logs to Splunk via the CSLS, and apply it to the task and API Gateway log groups. This condition is only true in staging, integration and production, so now we won't send logs to Splunk in our dev or build environments.

### Why did it change

We run our performance (load) tests in build and these generate several GB of logs each run. We share the daily Splunk ingest quota with all of Cabinet Office and we're regularly hitting that quota which means we've been asked to stop sending logs to Splunk when we run performance tests.

It's much simpler to simply not send logs to Splunk in build at all. If we need to look at application logs for any reason we still have them in Cloudwatch, or we can try to replicate an issue in a higher environment where we do export the logs.

### Related links

See the almost identical PR for the backend: https://github.com/alphagov/di-account-management-backend/pull/153

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
