### PR TITLE
BAU: Enable webchat in integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -203,7 +203,7 @@ Mappings:
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "1"
       WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app/loader/main.js"
-      SUPPORTWEBCHATCONTACT: "0"
+      SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"
       CONTACTEMAILSERVICEURL: "https://signin.integration.account.gov.uk/contact-us-from-triage-page"


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Enable webchat in integration
### Why did it change

We thought our suppliers had access to the GDS VPN and therefore could access the webchat in our IP-restricted staging environment. That's turned out not to be true.

We could gather their IP ranges and add them to the allowlist, but it's easier to simply enable the webchat in integration where we don't restrict by IP address.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing

N/A 
