### PR TITLE
OLH-1219: Remove LITE from Services you can use list

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -241,10 +241,6 @@
               "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
             },
             {
-              "text": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
-              "href": "https://exporter.lite.private-beta.service.trade.gov.uk/"
-            },
-            {
               "text": "Llofnodwch eich gweithred morgais",
               "href": "https://sign-your-mortgage-deed.landregistry.gov.uk"
             },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -233,10 +233,6 @@
               "href": "https://www.gov.uk/email/manage?from=your-services"
             },
             {
-              "text": "LITE (Licensing for International Trade and Enterprise)",
-              "href": "https://exporter.lite.private-beta.service.trade.gov.uk/"
-            },
-            {
               "text": "Manage apprenticeships",
               "href": "https://www.gov.uk/sign-in-apprenticeship-service-account"
             },


### PR DESCRIPTION
## Proposed changes
Remove LITE from the services you can use list on the Your services page

### What changed
Removed the link to the LITE service from the translations object for English and Welsh

<!-- Describe the changes in detail - the "what"-->

The LITE link on this list links into the authenticated part of their service which means a user who clicks on this link gets signed in to LITE and gets a service card for them, which may be accidental.

LITE are still in private beta so don’t have a start page we can link to from this list. Their being in private beta also means we probably shouldn’t be linking to them from this list anyway.


### Related links
[
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->](https://govukverify.atlassian.net/browse/OLH-1219)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing

Navigate to 

1. https://home.staging.account.gov.uk//your-services?lng=cy
2. https://home.staging.account.gov.uk//your-services?lng=en

In both pages, you should not see the LITE service listed any longer

## How to review
