### PR TITLE
OLH-1261: Use the latest version of localstack in the Github actions pipeline.

### DIFF
--- a/.github/workflows/build-test-application.yml
+++ b/.github/workflows/build-test-application.yml
@@ -30,9 +30,9 @@ jobs:
     timeout-minutes: 15
     services:
       localstack:
-        image: localstack/localstack:1.3.1
+        image: localstack/localstack:3.0.0
         env:
-          SERVICES: kms,sns,dynamodb
+          SERVICES: kms,sns,dynamodb,sqs
           HOSTNAME_EXTERNAL: localstack
           AWS_DEFAULT_REGION: eu-west-2
           AWS_ACCESS_KEY_ID: na


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use localstack v3.0.0 in the Github actions pipeline.

### Why did it change

This is required because we use the `ubuntu-latest` action runner which has just switched over to a new version of Ubuntu. The new version has a boto that's incompatible with the old version of localstack we were using previously.

Note this doesn't change the version of localstack we use for local development. This version works in the pipeline, and the main priority is getting that unblocked. We can come back and upgrade the version in `docker-compose.yml` later.

### Related links

See @andrew-moores work on https://github.com/alphagov/di-account-management-frontend/pull/1108

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

If the tests pass, this is a success. 