### PR TITLE
OLH-1262: Include user IDs in triage page audit events

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -166,7 +166,11 @@ export interface QueryParameters {
   theme?: string;
 }
 
-export const MISSING_SESSION_VALUE_SPECIAL_CASE = "";
+export const MISSING_APP_SESSION_ID_SPECIAL_CASE = "No app session ID";
+export const MISSING_SESSION_ID_SPECIAL_CASE = "No session ID";
+export const MISSING_PERSISTENT_SESSION_ID_SPECIAL_CASE =
+  "No persistent session ID";
+export const MISSING_USER_ID_SPECIAL_CASE = "No user ID";
 
 export type ParamName = keyof QueryParameters;
 

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -9,6 +9,7 @@ import { SinonStub, stub } from "sinon";
 import { SendMessageCommandOutput, SQSClient } from "@aws-sdk/client-sqs";
 import { I18NextRequest } from "i18next-http-middleware";
 import { AuditEvent } from "../../../services/types";
+import { MISSING_APP_SESSION_ID_SPECIAL_CASE } from "../../../app.constants";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 const MOCK_REFERENCE_CODE = "123456";
@@ -242,7 +243,7 @@ describe("Contact GOV.UK One Login controller", () => {
         {
           fromURL: undefined,
           referenceCode: "123456",
-          appSessionId: "",
+          appSessionId: MISSING_APP_SESSION_ID_SPECIAL_CASE,
           appErrorCode: undefined,
           sessionId: "sessionId",
           persistentSessionId: "persistentSessionId",

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -25,6 +25,7 @@ export interface AuditEvent extends Event {
 export interface User {
   session_id: string;
   persistent_session_id: string;
+  user_id: string;
 }
 
 export interface Platform {
@@ -36,4 +37,5 @@ export interface Extensions {
   app_session_id: string;
   app_error_code: string;
   reference_code: string;
+  is_signed_in?: boolean;
 }

--- a/test/unit/services/event-service.test.ts
+++ b/test/unit/services/event-service.test.ts
@@ -3,7 +3,12 @@ import { describe } from "mocha";
 import { sinon } from "../../utils/test-utils";
 import { SqsService } from "../../../src/utils/types";
 import { eventService } from "../../../src/services/event-service";
-import { MISSING_SESSION_VALUE_SPECIAL_CASE } from "../../../src/app.constants";
+import {
+  MISSING_APP_SESSION_ID_SPECIAL_CASE,
+  MISSING_PERSISTENT_SESSION_ID_SPECIAL_CASE,
+  MISSING_SESSION_ID_SPECIAL_CASE,
+  MISSING_USER_ID_SPECIAL_CASE,
+} from "../../../src/app.constants";
 
 describe("eventService", () => {
   let sqs: SqsService;
@@ -29,6 +34,10 @@ describe("eventService", () => {
             appSessionId: "test-app-session-id",
           },
           referenceCode: "test-reference-code",
+          user_id: "test-user-id",
+          user: {
+            isAuthenticated: true,
+          },
         },
       };
 
@@ -47,14 +56,16 @@ describe("eventService", () => {
       expect(result.user.persistent_session_id).to.equal(
         "test-persistent-session-id"
       );
+      expect(result.user.user_id).to.equal("test-user-id");
       expect(result.platform.user_agent).to.equal("test-user-agent");
       expect(result.extensions.from_url).to.equal("test-from-url");
       expect(result.extensions.app_error_code).to.equal("test-error-code");
       expect(result.extensions.app_session_id).to.equal("test-app-session-id");
       expect(result.extensions.reference_code).to.equal("test-reference-code");
+      expect(result.extensions.is_signed_in).to.equal(true);
     });
 
-    it("should handle missing session IDs", () => {
+    it("should handle missing IDs", () => {
       const service = eventService(sqs);
 
       const mockReq: any = {
@@ -68,11 +79,13 @@ describe("eventService", () => {
 
       const result = service.buildAuditEvent(mockReq, mockRes, "TEST_EVENT");
 
-      expect(result.user.session_id).to.equal(
-        MISSING_SESSION_VALUE_SPECIAL_CASE
-      );
+      expect(result.user.session_id).to.equal(MISSING_SESSION_ID_SPECIAL_CASE);
       expect(result.user.persistent_session_id).to.equal(
-        MISSING_SESSION_VALUE_SPECIAL_CASE
+        MISSING_PERSISTENT_SESSION_ID_SPECIAL_CASE
+      );
+      expect(result.user.user_id).to.equal(MISSING_USER_ID_SPECIAL_CASE);
+      expect(result.extensions.app_session_id).to.equal(
+        MISSING_APP_SESSION_ID_SPECIAL_CASE
       );
     });
 
@@ -98,7 +111,7 @@ describe("eventService", () => {
       expect(result.extensions.from_url).to.be.undefined;
       expect(result.extensions.app_error_code).to.be.undefined;
       expect(result.extensions.app_session_id).to.equal(
-        MISSING_SESSION_VALUE_SPECIAL_CASE
+        MISSING_APP_SESSION_ID_SPECIAL_CASE
       );
     });
   });


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add two new fields to the audit events emitted by the triage page - `user.user_id` and `extensions.is_signed_in`.

This also changes the string we send for session etc. IDs when a user is signed out. This will make it more obvious to TSD if the session is missing because of a bug when sending the event, or if the user is signed out.

### Why did it change

The Technical Service Desk have requested we add the user ID to help them match events between sessions / users. The user ID will be hashed by TxMA, so we also add a new field to the unhashed `extensions` object that will tell TSD if a user is signed in when we sent the event.

### Related links

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I have deployed this branch to dev and
1. Signed in, then visited the triage page
2. Verified the event is still sent to the audit queue
3. Read the contents of the event and verified it includes my user ID
4. Signed out, cleared my cookies and gone back to the triage page
5. Read the contents of the event and verified it has the new 'empty state' values for the IDs