### PR TITLE
OLH-1214 - Add docker registry login step to allow non-dev builds to …

### DIFF
--- a/.github/workflows/validate-docker-image.yml
+++ b/.github/workflows/validate-docker-image.yml
@@ -44,6 +44,13 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # pin@v1
 
+      - name: Login to GDS Dev Dynatrace Container Registry
+        uses: docker/login-action@1f401f745bf57e30b3a2800ad308a87d2ebdf14b
+        with:
+          registry: khw46367.live.dynatrace.com
+          username: khw46367
+          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+
       - name: Build Docker Image
         id: build-image
         env:


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
Add login step to non-dev GitHub action to allow Docker image to be built using the Dyantrace container registry.
### What changed

<!-- Describe the changes in detail - the "what"-->
Non-dev GitHub action.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Becasue the GitHub action wasn't logged in to the DynaTrace container registry it couldn't pull the required image during the build step.
### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

<!-- Provide a summary of any manual testing you've done -->
Cannot be tested until merged to main.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
Compare to validate-docker-image-dev action.