### PR TITLE
OLH-1283 - Enable deletion protection for frontend load balancer

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -968,6 +968,8 @@ Resources:
           Value: !Ref AccessLogsBucket
         - Key: routing.http.drop_invalid_header_fields.enabled
           Value: true
+        - Key: deletion_protection.enabled
+          Value: true
         - !Ref AWS::NoValue
       Tags:
         - Key: Product


### PR DESCRIPTION
## Proposed changes
OLH-1283 - Enable deletion protection for frontend load balancer


### What changed
Enable deletion protection for frontend load balancer by adding the deletion_protection.enabled load balancer attribute and setting its value to true. If not configured, it is false by default.


### Why did it change
Security team flagged this as part of a high priority change based on the rules in AWS Config.

### Related links
https://govukverify.atlassian.net/browse/CPC-112

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing
Deployed the branch in the dev environment
Checked the load balancer attributes and confirmed deletion_protection.enabled is set to true
Checked the Aws Config Rule to confirm this specific violation no longer exist.

## How to review